### PR TITLE
Fixed sessions not being destroyed on expire by db table gateway

### DIFF
--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -151,14 +151,12 @@ class DbTableGateway implements SaveHandlerInterface
      */
     public function destroy($id)
     {
-        if (! (bool) $this->read($id, false)) {
-            return true;
-        }
-
-        return (bool) $this->tableGateway->delete([
+        $this->tableGateway->delete([
             $this->options->getIdColumn()   => $id,
             $this->options->getNameColumn() => $this->sessionName,
         ]);
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
When reading an expired session in the db table gateway they should
be removed right away by the destroy method. This doesn't really
happen because the destroy method uses the read method to see if
the session exists only to conclude the session doens't exist because
the read method returns false for expired sessions even when they
are still in the database.

Because a delete is an atomic operation that does not throw errors
when there is nothing to delete we should actually always just run
the delete operation.