### PR TITLE
Add cookie_samesite parameter

### DIFF
--- a/docs/book/config.md
+++ b/docs/book/config.md
@@ -22,6 +22,7 @@ Option                    | Data Type | Description
 `cookie_httponly`         | `boolean` | Marks the cookie as accessible only through the HTTP protocol.
 `cookie_lifetime`         | `integer` | Specifies the lifetime of the cookie in seconds which is sent to the browser.
 `cookie_path`             | `string`  | Specifies path to set in the session cookie.
+`cookie_samesite`         | `string`  | Specifies whether cookies should be sent along with cross-site requests.
 `cookie_secure`           | `boolean` | Specifies whether cookies should only be sent over secure connections.
 `entropy_length`          | `integer` | Specifies the number of bytes which will be read from the file specified in entropy_file. Removed in PHP 7.1.0.
 `entropy_file`            | `string`  | Defines a path to an external resource (file) which will be used as an additional entropy. Removed in PHP 7.1.0.

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -37,6 +37,9 @@ interface ConfigInterface
     public function setCookieDomain($cookieDomain);
     public function getCookieDomain();
 
+    public function setCookieSameSite($cookieSameSite);
+    public function getCookieSameSite();
+
     public function setCookieSecure($cookieSecure);
     public function getCookieSecure();
 

--- a/src/Config/StandardConfig.php
+++ b/src/Config/StandardConfig.php
@@ -53,6 +53,13 @@ class StandardConfig implements ConfigInterface
     protected $cookieDomain;
 
     /**
+     * session.cookie_samesite
+     *
+     * @var string
+     */
+    protected $cookieSameSite;
+
+    /**
      * session.cookie_secure
      *
      * @var bool
@@ -496,6 +503,32 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
+     * Set session.cookie_samesite
+     *
+     * @param  string $cookieSameSite
+     * @return StandardConfig
+     */
+    public function setCookieSameSite($cookieSameSite)
+    {
+        $this->cookieSameSite = (string) $cookieSameSite;
+        $this->setStorageOption('cookie_samesite', $this->cookieSameSite);
+        return $this;
+    }
+
+    /**
+     * Get session.cookie_samesite
+     *
+     * @return string
+     */
+    public function getCookieSameSite()
+    {
+        if (null === $this->cookieSameSite) {
+            $this->cookieSameSite = $this->getStorageOption('cookie_samesite');
+        }
+        return $this->cookieSameSite;
+    }
+
+    /**
      * Set session.cookie_secure
      *
      * @param  bool $cookieSecure
@@ -888,6 +921,7 @@ class StandardConfig implements ConfigInterface
             'cookie_httponly'     => $this->getCookieHttpOnly(),
             'cookie_lifetime'     => $this->getCookieLifetime(),
             'cookie_path'         => $this->getCookiePath(),
+            'cookie_samesite'     => $this->getCookieSameSite(),
             'cookie_secure'       => $this->getCookieSecure(),
             'name'                => $this->getName(),
             'remember_me_seconds' => $this->getRememberMeSeconds(),

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -392,6 +392,25 @@ class SessionConfigTest extends TestCase
         $this->config->setCookieDomain('D:\\WINDOWS\\System32\\drivers\\etc\\hosts');
     }
 
+    // session.cookie_samesite
+
+    public function testCookieSameSiteDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cookie_samesite'), $this->config->getCookieSameSite());
+    }
+
+    public function testCookieSameSiteIsMutable()
+    {
+        $this->config->setCookieSameSite('Strict');
+        $this->assertEquals('Strict', $this->config->getCookieSameSite());
+    }
+
+    public function testCookieSameSiteAltersIniSetting()
+    {
+        $this->config->setCookieSameSite('Strict');
+        $this->assertEquals('Strict', ini_get('session.cookie_samesite'));
+    }
+
     // session.cookie_secure
 
     public function testCookieSecureDefaultsToIniSettings(): void
@@ -889,6 +908,11 @@ class SessionConfigTest extends TestCase
                 'cookie_domain',
                 'getCookieDomain',
                 'getlaminas.org',
+            ],
+            [
+                'cookie_samesite',
+                'getCookieSameSite',
+                'Lax',
             ],
             [
                 'cookie_secure',

--- a/test/Config/StandardConfigTest.php
+++ b/test/Config/StandardConfigTest.php
@@ -230,6 +230,14 @@ class StandardConfigTest extends TestCase
         $this->config->setCookieDomain('D:\\WINDOWS\\System32\\drivers\\etc\\hosts');
     }
 
+    // session.cookie_samesite
+
+    public function testCookieSameSiteIsMutable()
+    {
+        $this->config->setCookieSameSite('Strict');
+        $this->assertEquals('Strict', $this->config->getCookieSameSite());
+    }
+
     // session.cookie_secure
 
     public function testCookieSecureIsMutable(): void
@@ -518,6 +526,11 @@ class StandardConfigTest extends TestCase
                 'cookie_domain',
                 'getCookieDomain',
                 'getlaminas.org',
+            ],
+            [
+                'cookie_samesite',
+                'getCookieSameSite',
+                'Lax',
             ],
             [
                 'cookie_secure',


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Add a `cookie_samesite` parameter, as requested in issue #25.

This parameter corresponds to the `session.cookie_samesite` setting that is [available since PHP 7.3.0](https://www.php.net/manual/en/session.configuration.php#ini.session.cookie-samesite). This setting provides a way to mitigate CSRF (Cross Site Request Forgery) attacks by asserting whether cookies are to be sent along with cross-site requests. It supports three values: `'None'`, `'Lax'`, or `'Strict'`.