### PR TITLE
doc typo: fix config key mismatch

### DIFF
--- a/docs/book/manager.md
+++ b/docs/book/manager.md
@@ -29,7 +29,7 @@ options in your local or global config:
 use Laminas\Session;
 
 return [
-    'session_manager' => [
+    'session' => [
         'config' => [
             'class' => Session\Config\SessionConfig::class,
             'options' => [


### PR DESCRIPTION
Later in the example the referred configuration key is `session` instead of `session_manager`.

There is actually a supported `session_manager` configuration key, but the example stands apart and examines this custom configuration by itself. Also, after spotting a `storage` key under `session_manager`, developers may be led to believe that a `storage` key is supported by internal factories (...at least...I know I was).

kind regards