### PR TITLE
Add cookie_samesite parameter

### DIFF
--- a/docs/book/config.md
+++ b/docs/book/config.md
@@ -22,6 +22,7 @@ Option                    | Data Type | Description
 `cookie_httponly`         | `boolean` | Marks the cookie as accessible only through the HTTP protocol.
 `cookie_lifetime`         | `integer` | Specifies the lifetime of the cookie in seconds which is sent to the browser.
 `cookie_path`             | `string`  | Specifies path to set in the session cookie.
+`cookie_samesite`         | `string`  | Specifies whether cookies should be sent along with cross-site requests.
 `cookie_secure`           | `boolean` | Specifies whether cookies should only be sent over secure connections.
 `entropy_length`          | `integer` | Specifies the number of bytes which will be read from the file specified in entropy_file. Removed in PHP 7.1.0.
 `entropy_file`            | `string`  | Defines a path to an external resource (file) which will be used as an additional entropy. Removed in PHP 7.1.0.

--- a/docs/book/config.md
+++ b/docs/book/config.md
@@ -22,7 +22,7 @@ Option                    | Data Type | Description
 `cookie_httponly`         | `boolean` | Marks the cookie as accessible only through the HTTP protocol.
 `cookie_lifetime`         | `integer` | Specifies the lifetime of the cookie in seconds which is sent to the browser.
 `cookie_path`             | `string`  | Specifies path to set in the session cookie.
-`cookie_samesite`         | `string`  | Specifies whether cookies should be sent along with cross-site requests.
+`cookie_samesite`         | `string`  | Specifies whether cookies should be sent along with cross-site requests. (Since 2.11.0)
 `cookie_secure`           | `boolean` | Specifies whether cookies should only be sent over secure connections.
 `entropy_length`          | `integer` | Specifies the number of bytes which will be read from the file specified in entropy_file. Removed in PHP 7.1.0.
 `entropy_file`            | `string`  | Defines a path to an external resource (file) which will be used as an additional entropy. Removed in PHP 7.1.0.

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -84,15 +84,6 @@ interface ConfigInterface
     public function getCookieDomain();
 
     /**
-     * @param bool $cookieSameSite
-     * @return void
-     */
-    public function setCookieSameSite($cookieSameSite);
-
-    /** @return bool */
-    public function getCookieSameSite();
-
-    /**
      * @param bool $cookieSecure
      * @return void
      */

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -84,6 +84,15 @@ interface ConfigInterface
     public function getCookieDomain();
 
     /**
+     * @param bool $cookieSameSite
+     * @return void
+     */
+    public function setCookieSameSite($cookieSameSite);
+
+    /** @return bool */
+    public function getCookieSameSite();
+
+    /**
      * @param bool $cookieSecure
      * @return void
      */

--- a/src/Config/SameSiteCookieCapableInterface.php
+++ b/src/Config/SameSiteCookieCapableInterface.php
@@ -1,15 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-session for the canonical source repository
- * @copyright https://github.com/laminas/laminas-session/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-session/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Session\Config;
 
-interface SameSiteCookieCapableInterface extends ConfigInterface
+interface SameSiteCookieCapableInterface
 {
+    /**
+     * @param string $cookieSameSite
+     * @return self
+     */
     public function setCookieSameSite($cookieSameSite);
+
+    /** @return string */
     public function getCookieSameSite();
 }

--- a/src/Config/SameSiteCookieCapableInterface.php
+++ b/src/Config/SameSiteCookieCapableInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-session for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-session/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Session\Config;
+
+interface SameSiteCookieCapableInterface extends ConfigInterface
+{
+    public function setCookieSameSite($cookieSameSite);
+    public function getCookieSameSite();
+}

--- a/src/Config/StandardConfig.php
+++ b/src/Config/StandardConfig.php
@@ -33,7 +33,7 @@ use const PHP_VERSION_ID;
 /**
  * Standard session configuration
  */
-class StandardConfig implements ConfigInterface
+class StandardConfig implements SameSiteCookieCapableInterface
 {
     /**
      * session.name

--- a/src/Config/StandardConfig.php
+++ b/src/Config/StandardConfig.php
@@ -33,7 +33,7 @@ use const PHP_VERSION_ID;
 /**
  * Standard session configuration
  */
-class StandardConfig implements SameSiteCookieCapableInterface
+class StandardConfig implements ConfigInterface, SameSiteCookieCapableInterface
 {
     /**
      * session.name

--- a/src/Config/StandardConfig.php
+++ b/src/Config/StandardConfig.php
@@ -71,6 +71,13 @@ class StandardConfig implements ConfigInterface
     protected $cookieDomain;
 
     /**
+     * session.cookie_samesite
+     *
+     * @var string
+     */
+    protected $cookieSameSite;
+
+    /**
      * session.cookie_secure
      *
      * @var bool
@@ -512,6 +519,32 @@ class StandardConfig implements ConfigInterface
     }
 
     /**
+     * Set session.cookie_samesite
+     *
+     * @param  string $cookieSameSite
+     * @return StandardConfig
+     */
+    public function setCookieSameSite($cookieSameSite)
+    {
+        $this->cookieSameSite = (string) $cookieSameSite;
+        $this->setStorageOption('cookie_samesite', $this->cookieSameSite);
+        return $this;
+    }
+
+    /**
+     * Get session.cookie_samesite
+     *
+     * @return string
+     */
+    public function getCookieSameSite()
+    {
+        if (null === $this->cookieSameSite) {
+            $this->cookieSameSite = $this->getStorageOption('cookie_samesite');
+        }
+        return $this->cookieSameSite;
+    }
+
+    /**
      * Set session.cookie_secure
      *
      * @param  bool $cookieSecure
@@ -912,6 +945,7 @@ class StandardConfig implements ConfigInterface
             'cookie_httponly'     => $this->getCookieHttpOnly(),
             'cookie_lifetime'     => $this->getCookieLifetime(),
             'cookie_path'         => $this->getCookiePath(),
+            'cookie_samesite'     => $this->getCookieSameSite(),
             'cookie_secure'       => $this->getCookieSecure(),
             'name'                => $this->getName(),
             'remember_me_seconds' => $this->getRememberMeSeconds(),

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -7,6 +7,7 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Config\ConfigInterface;
+use Laminas\Session\Config\SameSiteCookieCapableInterface;
 use Laminas\Session\Config\SessionConfig;
 
 use function class_exists;
@@ -58,6 +59,17 @@ class SessionConfigFactory implements FactoryInterface
                 'Invalid configuration class "%s" specified in "config_class" session configuration; must implement %s',
                 $class,
                 ConfigInterface::class
+            ));
+        }
+
+        if (
+            isset($config['cookie_samesite'])
+            && ! $sessionConfig instanceof SameSiteCookieCapableInterface
+        ) {
+            throw new ServiceNotCreatedException(sprintf(
+                'Invalid configuration class "%s". When configuration option "cookie_samesite" is used, the configuration class must implement %s',
+                $class,
+                SameSiteCookieCapableInterface::class
             ));
         }
         $sessionConfig->setOptions($config);

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -67,7 +67,8 @@ class SessionConfigFactory implements FactoryInterface
             && ! $sessionConfig instanceof SameSiteCookieCapableInterface
         ) {
             throw new ServiceNotCreatedException(sprintf(
-                'Invalid configuration class "%s". When configuration option "cookie_samesite" is used, the configuration class must implement %s',
+                'Invalid configuration class "%s". When configuration option "cookie_samesite" is used,'
+                . ' the configuration class must implement %s',
                 $class,
                 SameSiteCookieCapableInterface::class
             ));

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -395,6 +395,25 @@ class SessionConfigTest extends TestCase
         $this->config->setCookieDomain('D:\\WINDOWS\\System32\\drivers\\etc\\hosts');
     }
 
+    // session.cookie_samesite
+
+    public function testCookieSameSiteDefaultsToIniSettings()
+    {
+        $this->assertSame(ini_get('session.cookie_samesite'), $this->config->getCookieSameSite());
+    }
+
+    public function testCookieSameSiteIsMutable()
+    {
+        $this->config->setCookieSameSite('Strict');
+        $this->assertEquals('Strict', $this->config->getCookieSameSite());
+    }
+
+    public function testCookieSameSiteAltersIniSetting()
+    {
+        $this->config->setCookieSameSite('Strict');
+        $this->assertEquals('Strict', ini_get('session.cookie_samesite'));
+    }
+
     // session.cookie_secure
 
     public function testCookieSecureDefaultsToIniSettings(): void
@@ -900,6 +919,11 @@ class SessionConfigTest extends TestCase
                 'cookie_domain',
                 'getCookieDomain',
                 'getlaminas.org',
+            ],
+            [
+                'cookie_samesite',
+                'getCookieSameSite',
+                'Lax',
             ],
             [
                 'cookie_secure',

--- a/test/Config/StandardConfigTest.php
+++ b/test/Config/StandardConfigTest.php
@@ -225,6 +225,14 @@ class StandardConfigTest extends TestCase
         $this->config->setCookieDomain('D:\\WINDOWS\\System32\\drivers\\etc\\hosts');
     }
 
+    // session.cookie_samesite
+
+    public function testCookieSameSiteIsMutable()
+    {
+        $this->config->setCookieSameSite('Strict');
+        $this->assertEquals('Strict', $this->config->getCookieSameSite());
+    }
+
     // session.cookie_secure
 
     public function testCookieSecureIsMutable(): void
@@ -523,6 +531,11 @@ class StandardConfigTest extends TestCase
                 'cookie_domain',
                 'getCookieDomain',
                 'getlaminas.org',
+            ],
+            [
+                'cookie_samesite',
+                'getCookieSameSite',
+                'Lax',
             ],
             [
                 'cookie_secure',

--- a/test/Service/SessionConfigFactoryTest.php
+++ b/test/Service/SessionConfigFactoryTest.php
@@ -3,8 +3,8 @@
 namespace LaminasTest\Session\Service;
 
 use Laminas\ServiceManager\Config;
-use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\ServiceManager;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SessionConfig;
 use Laminas\Session\Config\StandardConfig;
@@ -82,13 +82,13 @@ class SessionConfigFactoryTest extends TestCase
             'config',
             [
                 'session_config' => [
-                    'config_class' => TestConfig::class,
+                    'config_class'    => TestConfig::class,
                     'cookie_samesite' => 'Lax',
                 ],
             ]
         );
         $this->expectException(ServiceNotCreatedException::class);
-        $this->expectExceptionMessage('Invalid configuration class "LaminasTest\Session\TestAsset\TestConfig". When configuration option "cookie_samesite" is used, the configuration class must implement Laminas\Session\Config\SameSiteCookieCapableInterface');
+        $this->expectExceptionMessage('"cookie_samesite"');
         $this->services->get(ConfigInterface::class);
     }
 }

--- a/test/Service/SessionConfigFactoryTest.php
+++ b/test/Service/SessionConfigFactoryTest.php
@@ -4,10 +4,12 @@ namespace LaminasTest\Session\Service;
 
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SessionConfig;
 use Laminas\Session\Config\StandardConfig;
 use Laminas\Session\Service\SessionConfigFactory;
+use LaminasTest\Session\TestAsset\TestConfig;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -72,5 +74,21 @@ class SessionConfigFactoryTest extends TestCase
         );
         $config = $this->services->get(ConfigInterface::class);
         self::assertEquals('laminas', $config->getName());
+    }
+
+    public function testServiceNotCreatedWhenInvalidSamesiteConfig()
+    {
+        $this->services->setService(
+            'config',
+            [
+                'session_config' => [
+                    'config_class' => TestConfig::class,
+                    'cookie_samesite' => 'Lax',
+                ],
+            ]
+        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('Invalid configuration class "LaminasTest\Session\TestAsset\TestConfig". When configuration option "cookie_samesite" is used, the configuration class must implement Laminas\Session\Config\SameSiteCookieCapableInterface');
+        $this->services->get(ConfigInterface::class);
     }
 }

--- a/test/TestAsset/TestConfig.php
+++ b/test/TestAsset/TestConfig.php
@@ -1,134 +1,168 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-session for the canonical source repository
- * @copyright https://github.com/laminas/laminas-session/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-session/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Session\TestAsset;
 
 use Laminas\Session\Config\ConfigInterface;
 
 class TestConfig implements ConfigInterface
 {
+    /**
+     * @param array $options
+     * @return void
+     */
     public function setOptions($options)
     {
-        return;
     }
 
+    /** @return void */
     public function getOptions()
     {
-        return;
     }
 
+    /**
+     * @param string $option
+     * @param mixed $value
+     * @return void
+     */
     public function setOption($option, $value)
     {
-        return;
     }
 
+    /**
+     * @param string $option
+     * @return void
+     */
     public function getOption($option)
     {
-        return;
     }
 
+    /**
+     * @param string $option
+     * @return void
+     */
     public function hasOption($option)
     {
-        return;
     }
 
+    /** @return void */
     public function toArray()
     {
-        return;
     }
 
+    /**
+     * @param string $name
+     * @return void
+     */
     public function setName($name)
     {
-        return;
     }
 
+    /** @return void */
     public function getName()
     {
-        return;
     }
 
+    /**
+     * @param string $savePath
+     * @return void
+     */
     public function setSavePath($savePath)
     {
-        return;
     }
 
+    /** @return void */
     public function getSavePath()
     {
-        return;
     }
 
+    /**
+     * @param int $cookieLifetime
+     * @return void
+     */
     public function setCookieLifetime($cookieLifetime)
     {
-        return;
     }
 
+    /** @return void */
     public function getCookieLifetime()
     {
-        return;
     }
 
+    /**
+     * @param string $cookiePath
+     * @return void
+     */
     public function setCookiePath($cookiePath)
     {
-        return;
     }
 
+    /** @return void */
     public function getCookiePath()
     {
-        return;
     }
 
+    /**
+     * @param string $cookieDomain
+     * @return void
+     */
     public function setCookieDomain($cookieDomain)
     {
-        return;
     }
 
+    /** @return void */
     public function getCookieDomain()
     {
-        return;
     }
 
+    /**
+     * @param bool $cookieSecure
+     * @return void
+     */
     public function setCookieSecure($cookieSecure)
     {
-        return;
     }
 
+    /** @return void */
     public function getCookieSecure()
     {
-        return;
     }
 
+    /**
+     * @param bool $cookieHttpOnly
+     * @return void
+     */
     public function setCookieHttpOnly($cookieHttpOnly)
     {
-        return;
     }
 
+    /** @return void */
     public function getCookieHttpOnly()
     {
-        return;
     }
 
+    /**
+     * @param bool $useCookies
+     * @return void
+     */
     public function setUseCookies($useCookies)
     {
-        return;
     }
 
+    /** @return void */
     public function getUseCookies()
     {
-        return;
     }
 
+    /**
+     * @param int $rememberMeSeconds
+     * @return void
+     */
     public function setRememberMeSeconds($rememberMeSeconds)
     {
-        return;
     }
 
+    /** @return void */
     public function getRememberMeSeconds()
     {
-        return;
     }
 }

--- a/test/TestAsset/TestConfig.php
+++ b/test/TestAsset/TestConfig.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-session for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-session/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Session\TestAsset;
+
+use Laminas\Session\Config\ConfigInterface;
+
+class TestConfig implements ConfigInterface
+{
+    public function setOptions($options)
+    {
+        return;
+    }
+
+    public function getOptions()
+    {
+        return;
+    }
+
+    public function setOption($option, $value)
+    {
+        return;
+    }
+
+    public function getOption($option)
+    {
+        return;
+    }
+
+    public function hasOption($option)
+    {
+        return;
+    }
+
+    public function toArray()
+    {
+        return;
+    }
+
+    public function setName($name)
+    {
+        return;
+    }
+
+    public function getName()
+    {
+        return;
+    }
+
+    public function setSavePath($savePath)
+    {
+        return;
+    }
+
+    public function getSavePath()
+    {
+        return;
+    }
+
+    public function setCookieLifetime($cookieLifetime)
+    {
+        return;
+    }
+
+    public function getCookieLifetime()
+    {
+        return;
+    }
+
+    public function setCookiePath($cookiePath)
+    {
+        return;
+    }
+
+    public function getCookiePath()
+    {
+        return;
+    }
+
+    public function setCookieDomain($cookieDomain)
+    {
+        return;
+    }
+
+    public function getCookieDomain()
+    {
+        return;
+    }
+
+    public function setCookieSecure($cookieSecure)
+    {
+        return;
+    }
+
+    public function getCookieSecure()
+    {
+        return;
+    }
+
+    public function setCookieHttpOnly($cookieHttpOnly)
+    {
+        return;
+    }
+
+    public function getCookieHttpOnly()
+    {
+        return;
+    }
+
+    public function setUseCookies($useCookies)
+    {
+        return;
+    }
+
+    public function getUseCookies()
+    {
+        return;
+    }
+
+    public function setRememberMeSeconds($rememberMeSeconds)
+    {
+        return;
+    }
+
+    public function getRememberMeSeconds()
+    {
+        return;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Add a cookie_samesite parameter, as requested in issue #25.

This parameter corresponds to the session.cookie_samesite setting that is available since PHP 7.3.0. This setting provides a way to mitigate CSRF (Cross Site Request Forgery) attacks by asserting whether cookies are to be sent along with cross-site requests. It supports three values: 'None', 'Lax', or 'Strict'.

This work supersedes pull request #30, as the original author Doug Sheffer @desheffer does not continue on it

