### PR TITLE
Update session bootstrap code to use the same config key used in Initializing the Session Manager

### DIFF
--- a/docs/book/manager.md
+++ b/docs/book/manager.md
@@ -88,11 +88,11 @@ class Module
         $container->httpUserAgent = $request->getServer()->get('HTTP_USER_AGENT');
 
         $config = $serviceManager->get('Config');
-        if (! isset($config['session'])) {
+        if (! isset($config['session_manager'])) {
             return;
         }
 
-        $sessionConfig = $config['session'];
+        $sessionConfig = $config['session_manager'];
 
         if (! isset($sessionConfig['validators'])) {
             return;
@@ -123,23 +123,18 @@ class Module
             'factories' => [
                 SessionManager::class => function ($container) {
                     $config = $container->get('config');
-                    if (! isset($config['session'])) {
+                    if (! isset($config['session_manager'])) {
                         $sessionManager = new SessionManager();
                         Container::setDefaultManager($sessionManager);
                         return $sessionManager;
                     }
 
-                    $session = $config['session'];
+                    $session = $config['session_manager'];
 
                     $sessionConfig = null;
                     if (isset($session['config'])) {
-                        $class = isset($session['config']['class'])
-                            ?  $session['config']['class']
-                            : SessionConfig::class;
-
-                        $options = isset($session['config']['options'])
-                            ?  $session['config']['options']
-                            : [];
+                        $class = $session['config']['class'] ?? SessionConfig::class;
+                        $options = $session['config']['options'] ?? [];
 
                         $sessionConfig = new $class();
                         $sessionConfig->setOptions($options);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

This is a fix to a code example in the session manager documentation.

The section "Initializing the Session Manager" defines example configuration for the session manager using the key `session_manager`, however, the corresponding code for bootstrapping the session and configuring the session manager are using the key `session` to look for this configuration. This commit updates the code to use to the correct config key `session_manager` instead of `session`.
