### PR TITLE
[Storage] Avoid get error getStorage() on null

### DIFF
--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -157,6 +157,10 @@ abstract class AbstractContainer extends ArrayObject
      */
     public function getManager()
     {
+        if (null === $this->manager) {
+            $this->setManager();
+        }
+
         return $this->manager;
     }
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

The error happen when I tried create php 8.1 support on https://github.com/laminas/laminas-mvc-plugin-fileprg/pull/18

```bash
Fatal error: Uncaught Error: Call to a member function getStorage() on null in /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/laminas/laminas-session/src/AbstractContainer.php:172
Stack trace:
#0 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/laminas/laminas-session/src/AbstractContainer.php(199): Laminas\Session\AbstractContainer->getStorage()
#1 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/laminas/laminas-session/src/AbstractContainer.php(480): Laminas\Session\AbstractContainer->verifyNamespace()
#2 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/laminas/laminas-stdlib/src/ArrayObject.php(480): Laminas\Session\AbstractContainer->exchangeArray(Array)
#3 [internal function]: Laminas\Stdlib\ArrayObject->__unserialize(Array)
#4 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/Util/PHP/AbstractPhpProcess.php(288): unserialize('a:4:{s:10:"test...')
#5 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/Util/PHP/AbstractPhpProcess.php(187): PHPUnit\Util\PHP\AbstractPhpProcess->processChildResult(Object(LaminasTest\Mvc\Plugin\FilePrg\FilePrgDataMergingTest), Object(PHPUnit\Framework\TestResult), 'a:4:{s:10:"test...', '')
#6 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/Framework/TestCase.php(878): PHPUnit\Util\PHP\AbstractPhpProcess->runTestJob('<?php\nuse PHPUn...', Object(LaminasTest\Mvc\Plugin\FilePrg\FilePrgDataMergingTest), Object(PHPUnit\Framework\TestResult))
#7 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/Framework/TestSuite.php(665): PHPUnit\Framework\TestCase->run(Object(PHPUnit\Framework\TestResult))
#8 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/Framework/TestSuite.php(665): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#9 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/Framework/TestSuite.php(665): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#10 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(671): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#11 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/TextUI/Command.php(148): PHPUnit\TextUI\TestRunner->run(Object(PHPUnit\Framework\TestSuite), Array, Array, true)
#12 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/TextUI/Command.php(101): PHPUnit\TextUI\Command->run(Array, true)
#13 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/phpunit(61): PHPUnit\TextUI\Command::main()
#14 {main}

Next PHPUnit\TextUI\Exception: Call to a member function getStorage() on null in /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/TextUI/Command.php:103
Stack trace:
#0 /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/phpunit(61): PHPUnit\TextUI\Command::main()
#1 {main}
  thrown in /Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/vendor/phpunit/phpunit/src/TextUI/Command.php on line 103
```

It is probably a PHPUnit bug ? Like should be called early in `__construct()` for `setManager()`. Even with this patch, the PHPUnit on https://github.com/laminas/laminas-mvc-plugin-fileprg/pull/18 got invalid result:

```bash
1) LaminasTest\Mvc\Plugin\FilePrg\FilePrgDataMergingTest::testCorrectInputDataMerging
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
                 'name' => 'test.jpg'
                 'type' => 'image/jpeg'
                 'size' => 20480
-                'tmp_name' => '/Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/test/TestAsset/testfile.jpg'
+                'tmp_name' => '/Users/samsonasik/www/oss-contribute/laminas-mvc-plugin-fileprg/test/TestAsset/nullfile_copy'
```

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
