### PR TITLE
Early return from SessionManager::destroy() if headers have already been sent

### DIFF
--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -194,11 +194,7 @@ class SessionManager extends AbstractManager
      */
     public function destroy(?array $options = null)
     {
-        if (! $this->sessionExists()) {
-            return;
-        }
-
-        if (headers_sent()) {
+        if (headers_sent() || ! $this->sessionExists()) {
             return;
         }
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -198,6 +198,10 @@ class SessionManager extends AbstractManager
             return;
         }
 
+        if (headers_sent()) {
+            return;
+        }
+
         if (null === $options) {
             $options = $this->defaultDestroyOptions;
         } else {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

In some situations `SessionManager::sessionExists()` may return `true` based on headers having been sent. However, in these cases `session_destroy()` will fail. This change will return early from the `destroy()` method if headers have already been sent and nothing else can be done.

