### PR TITLE
Fix warning in SessionManager::destroy() for headers already sent and actual fix for trying to destroy non-existent session

### DIFF
--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -205,7 +205,7 @@ class SessionManager extends AbstractManager
         }
 
         session_destroy();
-        if ($options['send_expire_cookie']) {
+        if (! headers_sent() && $options['send_expire_cookie']) {
             $this->expireSessionCookie();
         }
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -194,8 +194,11 @@ class SessionManager extends AbstractManager
      */
     public function destroy(?array $options = null)
     {
-        // session_destroy() requires active session while method $this->sessionExists() includes other conditions 
+        // session_destroy() requires active session while method
+        // $this->sessionExists() includes other conditions
         if (session_status() !== PHP_SESSION_ACTIVE) {
+            return;
+        }
 
         if (null === $options) {
             $options = $this->defaultDestroyOptions;

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -194,9 +194,8 @@ class SessionManager extends AbstractManager
      */
     public function destroy(?array $options = null)
     {
+        // session_destroy() requires active session while method $this->sessionExists() includes other conditions 
         if (session_status() !== PHP_SESSION_ACTIVE) {
-            return;
-        }
 
         if (null === $options) {
             $options = $this->defaultDestroyOptions;

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -194,7 +194,7 @@ class SessionManager extends AbstractManager
      */
     public function destroy(?array $options = null)
     {
-        if (headers_sent() || ! $this->sessionExists()) {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
             return;
         }
 

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -24,6 +24,7 @@ use function array_merge;
 use function extension_loaded;
 use function headers_sent;
 use function ini_get;
+use function ob_flush;
 use function preg_match;
 use function range;
 use function restore_error_handler;
@@ -477,6 +478,21 @@ class SessionManagerTest extends TestCase
         $this->manager->start();
         $storage        = $this->manager->getStorage();
         $storage['foo'] = 'bar';
+        $this->manager->destroy(['clear_storage' => true]);
+        self::assertFalse(isset($storage['foo']));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testDestroySessionWhenHeadersHaveBeenSent(): void
+    {
+        $this->manager = new SessionManager();
+        $this->manager->start();
+        $storage        = $this->manager->getStorage();
+        $storage['foo'] = 'bar';
+        echo ' ';
+        ob_flush();
         $this->manager->destroy(['clear_storage' => true]);
         self::assertFalse(isset($storage['foo']));
     }


### PR DESCRIPTION
Fixes problem introduced by #79
 
#79 introduced a fix for trying to destroy non-existent session when headers were already sent. However fix inadvertently prevented valid attempts to destroy session when session is active but headers were already sent.
