### PR TITLE
Upgrade Psalm to 5.22.x, Re-enable a number of tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,5 +7,31 @@ on:
     tags:
 
 jobs:
-  ci:
-    uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x
+  matrix:
+    name: Generate job matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Gather CI configuration
+        id: matrix
+        uses: laminas/laminas-ci-matrix-action@v1
+
+  qa:
+    name: QA Checks
+    needs: [matrix]
+    runs-on: ${{ matrix.operatingSystem }}
+    services:
+      mongo:
+        image: mongo
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
+    steps:
+      - name: ${{ matrix.name }}
+        uses: laminas/laminas-continuous-integration-action@v1
+        with:
+          job: ${{ matrix.job }}
+        env:
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MONGODB: true
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MONGODB_CONNECTION_STRING: mongodb://mongo/

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,21 @@ jobs:
     services:
       mongo:
         image: mongo
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: 'password'
+          MYSQL_ROOT_HOST: '%'
+          MYSQL_USER: 'gha'
+          MYSQL_PASSWORD: 'password'
+          MYSQL_DATABASE: 'laminas_session'
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+        ports:
+          - 3306
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
@@ -35,3 +50,8 @@ jobs:
         env:
           TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MONGODB: true
           TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MONGODB_CONNECTION_STRING: mongodb://mongo/
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL: true
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_HOSTNAME: mysql
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_USERNAME: gha
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_PASSWORD: password
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_DATABASE: laminas_session

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,6 +39,19 @@ jobs:
           --health-retries 3
         ports:
           - 3306
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: 'gha'
+          POSTGRES_PASSWORD: 'password'
+          POSTGRES_DB: 'laminas_session'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+        ports:
+          - 5432
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
@@ -55,3 +68,8 @@ jobs:
           TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_USERNAME: gha
           TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_PASSWORD: password
           TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_DATABASE: laminas_session
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_PGSQL: true
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_PGSQL_HOSTNAME: postgres
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_PGSQL_USERNAME: gha
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_PGSQL_PASSWORD: password
+          TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_PGSQL_DATABASE: laminas_session

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -2,9 +2,11 @@
     "extensions": [
         "mongodb",
         "mysql",
-        "pgsql"
+        "pgsql",
+        "xdebug"
     ],
     "ignore_php_platform_requirements": {
-        "8.3": true
-    }
+        "8.3": false
+    },
+    "backwardCompatibilityCheck": true
 }

--- a/composer.json
+++ b/composer.json
@@ -38,16 +38,17 @@
         "laminas/laminas-stdlib": "^3.18"
     },
     "require-dev": {
-        "laminas/laminas-cache": "^3.12.0",
+        "ext-xdebug": "*",
+        "laminas/laminas-cache": "^3.12.1",
         "laminas/laminas-cache-storage-adapter-memory": "^2.3",
         "laminas/laminas-coding-standard": "~2.5.0",
-        "laminas/laminas-db": "^2.18.0",
+        "laminas/laminas-db": "^2.19.0",
         "laminas/laminas-http": "^2.19",
-        "laminas/laminas-validator": "^2.46.0",
+        "laminas/laminas-validator": "^2.49.0",
         "mongodb/mongodb": "~1.17.0",
-        "phpunit/phpunit": "^9.6.15",
+        "phpunit/phpunit": "^9.6.17",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.18"
+        "vimeo/psalm": "^5.22.2"
     },
     "suggest": {
         "laminas/laminas-cache": "Laminas\\Cache component",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95bbe29e00903423f10604d2ba7d71e2",
+    "content-hash": "6be5308fe9ba618a4de19f1df12f5266",
     "packages": [
         {
             "name": "laminas/laminas-eventmanager",
@@ -166,16 +166,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.18.0",
+            "version": "3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf"
+                "reference": "6a192dd0882b514e45506f533b833b623b78fff3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
-                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/6a192dd0882b514e45506f533b833b623b78fff3",
+                "reference": "6a192dd0882b514e45506f533b833b623b78fff3",
                 "shasum": ""
             },
             "require": {
@@ -186,10 +186,10 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "^2.5",
-                "phpbench/phpbench": "^1.2.14",
-                "phpunit/phpunit": "^10.3.3",
+                "phpbench/phpbench": "^1.2.15",
+                "phpunit/phpunit": "^10.5.8",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15.0"
+                "vimeo/psalm": "^5.20.0"
             },
             "type": "library",
             "autoload": {
@@ -221,7 +221,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-09-19T10:15:21+00:00"
+            "time": "2024-01-19T12:39:49+00:00"
         },
         {
             "name": "psr/container",
@@ -1015,16 +1015,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "85193c0b0cb5c47894b5eaec906e946f054e7077"
+                "reference": "f92996c4d5c1a696a6a970e20f7c4216200fcc42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/85193c0b0cb5c47894b5eaec906e946f054e7077",
-                "reference": "85193c0b0cb5c47894b5eaec906e946f054e7077",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/f92996c4d5c1a696a6a970e20f7c4216200fcc42",
+                "reference": "f92996c4d5c1a696a6a970e20f7c4216200fcc42",
                 "shasum": ""
             },
             "require": {
@@ -1064,7 +1064,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.0.0"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.1.0"
             },
             "funding": [
                 {
@@ -1072,7 +1072,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-17T21:38:23+00:00"
+            "time": "2024-02-07T09:43:46+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -1135,16 +1135,16 @@
         },
         {
             "name": "laminas/laminas-cache",
-            "version": "3.12.0",
+            "version": "3.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "66cf9a209163cadc65d93483667b995c5ead1563"
+                "reference": "bf8bc7f92e15925991c46079c6cd727372af5a46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/66cf9a209163cadc65d93483667b995c5ead1563",
-                "reference": "66cf9a209163cadc65d93483667b995c5ead1563",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/bf8bc7f92e15925991c46079c6cd727372af5a46",
+                "reference": "bf8bc7f92e15925991c46079c6cd727372af5a46",
                 "shasum": ""
             },
             "require": {
@@ -1232,7 +1232,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-11-06T18:52:54+00:00"
+            "time": "2024-01-19T20:42:11+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
@@ -1359,21 +1359,21 @@
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.18.0",
+            "version": "2.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "4df7a3f7ffe268e8683306fcec125c269408b295"
+                "reference": "5d8c89d767d4dac7b710c8c6d967f3780f7a5f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/4df7a3f7ffe268e8683306fcec125c269408b295",
-                "reference": "4df7a3f7ffe268e8683306fcec125c269408b295",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/5d8c89d767d4dac7b710c8c6d967f3780f7a5f6a",
+                "reference": "5d8c89d767d4dac7b710c8c6d967f3780f7a5f6a",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-stdlib": "^3.7.1",
-                "php": "~8.0.0 || ~8.1.0|| ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "zendframework/zend-db": "*"
@@ -1426,7 +1426,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-05-05T16:22:28+00:00"
+            "time": "2024-02-01T18:53:10+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -1671,16 +1671,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.46.0",
+            "version": "2.49.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "98330256f8d8a1357a93f6f7f1a987036aff6329"
+                "reference": "d58c2e7d3cd420554400dd8cca694fafa3b8e45f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/98330256f8d8a1357a93f6f7f1a987036aff6329",
-                "reference": "98330256f8d8a1357a93f6f7f1a987036aff6329",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/d58c2e7d3cd420554400dd8cca694fafa3b8e45f",
+                "reference": "d58c2e7d3cd420554400dd8cca694fafa3b8e45f",
                 "shasum": ""
             },
             "require": {
@@ -1694,16 +1694,16 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "^2.5",
-                "laminas/laminas-db": "^2.18",
-                "laminas/laminas-filter": "^2.33",
-                "laminas/laminas-i18n": "^2.24.1",
-                "laminas/laminas-session": "^2.17",
+                "laminas/laminas-db": "^2.19",
+                "laminas/laminas-filter": "^2.34",
+                "laminas/laminas-i18n": "^2.26.0",
+                "laminas/laminas-session": "^2.18",
                 "laminas/laminas-uri": "^2.11.0",
-                "phpunit/phpunit": "^10.5.2",
+                "phpunit/phpunit": "^10.5.10",
                 "psalm/plugin-phpunit": "^0.18.4",
                 "psr/http-client": "^1.0.3",
                 "psr/http-factory": "^1.0.2",
-                "vimeo/psalm": "^5.17"
+                "vimeo/psalm": "^5.22.1"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
@@ -1751,7 +1751,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-01-03T12:43:04+00:00"
+            "time": "2024-02-22T16:46:06+00:00"
         },
         {
             "name": "mongodb/mongodb",
@@ -1891,16 +1891,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.2.0",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
+                "reference": "132c75c7dd83e45353ebb9c6c9f591952995bbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
-                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/132c75c7dd83e45353ebb9c6c9f591952995bbf0",
+                "reference": "132c75c7dd83e45353ebb9c6c9f591952995bbf0",
                 "shasum": ""
             },
             "require": {
@@ -1911,7 +1911,7 @@
                 "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0 || ~10.0",
                 "squizlabs/php_codesniffer": "~3.5"
             },
             "type": "library",
@@ -1936,9 +1936,9 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.4.1"
             },
-            "time": "2023-04-09T17:37:40+00:00"
+            "time": "2024-01-31T06:18:54+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1998,20 +1998,21 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -2052,9 +2053,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -2318,16 +2325,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.30",
+            "version": "9.2.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
                 "shasum": ""
             },
             "require": {
@@ -2384,7 +2391,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
             },
             "funding": [
                 {
@@ -2392,7 +2399,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:47:57+00:00"
+            "time": "2024-03-02T06:37:42+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2637,16 +2644,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "9.6.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
                 "shasum": ""
             },
             "require": {
@@ -2720,7 +2727,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
             },
             "funding": [
                 {
@@ -2736,7 +2743,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2024-02-23T13:14:51+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3051,16 +3058,16 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -3095,7 +3102,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -3103,7 +3110,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -3349,16 +3356,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -3403,7 +3410,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -3411,7 +3418,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -3478,16 +3485,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -3543,7 +3550,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
             "funding": [
                 {
@@ -3551,20 +3558,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -3607,7 +3614,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
             "funding": [
                 {
@@ -3615,7 +3622,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4076,16 +4083,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "96be97e664c87613121d073ea39af4c74e57a7f8"
+                "reference": "c95fd4db94ec199f798d4b5b4a81757bd20d88ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/96be97e664c87613121d073ea39af4c74e57a7f8",
-                "reference": "96be97e664c87613121d073ea39af4c74e57a7f8",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/c95fd4db94ec199f798d4b5b4a81757bd20d88ab",
+                "reference": "c95fd4db94ec199f798d4b5b4a81757bd20d88ab",
                 "shasum": ""
             },
             "require": {
@@ -4123,7 +4130,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.2.2"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.2.3"
             },
             "funding": [
                 {
@@ -4135,20 +4142,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-14T14:08:51+00:00"
+            "time": "2024-02-07T10:39:02+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
                 "shasum": ""
             },
             "require": {
@@ -4158,11 +4165,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -4215,20 +4222,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-02-16T15:06:51+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.2",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625"
+                "reference": "0d9e4eb5ad413075624378f474c4167ea202de78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0254811a143e6bc6c8deea08b589a7e68a37f625",
-                "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0d9e4eb5ad413075624378f474c4167ea202de78",
+                "reference": "0d9e4eb5ad413075624378f474c4167ea202de78",
                 "shasum": ""
             },
             "require": {
@@ -4293,7 +4300,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.2"
+                "source": "https://github.com/symfony/console/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -4309,7 +4316,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-10T16:15:48+00:00"
+            "time": "2024-02-22T20:27:10+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4380,16 +4387,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.0",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "952a8cb588c3bc6ce76f6023000fb932f16a6e59"
+                "reference": "7f3b1755eb49297a0827a7575d5d2b2fd11cc9fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/952a8cb588c3bc6ce76f6023000fb932f16a6e59",
-                "reference": "952a8cb588c3bc6ce76f6023000fb932f16a6e59",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7f3b1755eb49297a0827a7575d5d2b2fd11cc9fb",
+                "reference": "7f3b1755eb49297a0827a7575d5d2b2fd11cc9fb",
                 "shasum": ""
             },
             "require": {
@@ -4423,7 +4430,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.0"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -4439,20 +4446,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-26T17:27:13+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
                 "shasum": ""
             },
             "require": {
@@ -4466,9 +4473,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -4505,7 +4509,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4521,20 +4525,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "875e90aeea2777b6f135677f618529449334a612"
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
-                "reference": "875e90aeea2777b6f135677f618529449334a612",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
                 "shasum": ""
             },
             "require": {
@@ -4545,9 +4549,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -4586,7 +4587,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4602,20 +4603,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
                 "shasum": ""
             },
             "require": {
@@ -4626,9 +4627,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -4670,7 +4668,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4686,20 +4684,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
                 "shasum": ""
             },
             "require": {
@@ -4713,9 +4711,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -4753,7 +4748,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4769,7 +4764,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -5011,16 +5006,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.2",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "7cb80bc10bfcdf6b5492741c0b9357dac66940bc"
+                "reference": "4e465a95bdc32f49cf4c7f07f751b843bbd6dcd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/7cb80bc10bfcdf6b5492741c0b9357dac66940bc",
-                "reference": "7cb80bc10bfcdf6b5492741c0b9357dac66940bc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4e465a95bdc32f49cf4c7f07f751b843bbd6dcd9",
+                "reference": "4e465a95bdc32f49cf4c7f07f751b843bbd6dcd9",
                 "shasum": ""
             },
             "require": {
@@ -5077,7 +5072,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.2"
+                "source": "https://github.com/symfony/string/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -5093,20 +5088,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-10T16:15:48+00:00"
+            "time": "2024-02-01T13:16:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -5135,7 +5130,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -5143,20 +5138,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.18.0",
+            "version": "5.22.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "b113f3ed0259fd6e212d87c3df80eec95a6abf19"
+                "reference": "d768d914152dbbf3486c36398802f74e80cfde48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/b113f3ed0259fd6e212d87c3df80eec95a6abf19",
-                "reference": "b113f3ed0259fd6e212d87c3df80eec95a6abf19",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d768d914152dbbf3486c36398802f74e80cfde48",
+                "reference": "d768d914152dbbf3486c36398802f74e80cfde48",
                 "shasum": ""
             },
             "require": {
@@ -5179,7 +5174,7 @@
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.16",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-                "sebastian/diff": "^4.0 || ^5.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",
                 "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
@@ -5253,7 +5248,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2023-12-16T09:37:35+00:00"
+            "time": "2024-02-22T23:39:07+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -5377,7 +5372,9 @@
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "ext-xdebug": "*"
+    },
     "platform-overrides": {
         "php": "8.1.99"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,12 +28,6 @@
     <php>
         <ini name="date.timezone" value="UTC" />
 
-        <!-- OB_ENABLED should be enabled for some tests to check if all
-             functionality works as expected. Such tests include those for
-             Laminas\Soap and Laminas\Session, which require that headers not be sent
-             in order to work. -->
-        <env name="TESTS_LAMINAS_OB_ENABLED" value="false" />
-
         <env name="TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL" value="false" />
         <env name="TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_HOSTNAME" value="localhost" />
         <env name="TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL_USERNAME" value="travis" />

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -48,7 +48,7 @@
       <code><![CDATA[$storage[$name][$key]]]></code>
       <code><![CDATA[$storage[$name][$key]]]></code>
       <code><![CDATA[$storage[$name][$key]]]></code>
-      <code><![CDATA[$storage[$name][$key]]]></code>
+      <code><![CDATA[$storage[$name][$offset]]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$metadata['EXPIRE_HOPS']['hops']]]></code>
@@ -100,7 +100,6 @@
     </MoreSpecificReturnType>
     <ParamNameMismatch>
       <code><![CDATA[$input]]></code>
-      <code><![CDATA[$key]]></code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
       <code><![CDATA[$key]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.18.0@b113f3ed0259fd6e212d87c3df80eec95a6abf19">
+<files psalm-version="5.22.2@d768d914152dbbf3486c36398802f74e80cfde48">
   <file src="src/AbstractContainer.php">
     <DocblockTypeContradiction>
       <code><![CDATA[(null === $key)
             && is_array($metadata)]]></code>
       <code><![CDATA[(null === $key)
             && is_array($metadata)]]></code>
-      <code>null === $key</code>
-      <code>null === $key</code>
-      <code>null === static::$defaultManager</code>
+      <code><![CDATA[null === $key]]></code>
+      <code><![CDATA[null === $key]]></code>
+      <code><![CDATA[null === static::$defaultManager]]></code>
     </DocblockTypeContradiction>
     <InvalidStringClass>
-      <code>new static::$managerDefaultClass()</code>
+      <code><![CDATA[new static::$managerDefaultClass()]]></code>
     </InvalidStringClass>
     <LessSpecificReturnStatement>
-      <code>$container</code>
-      <code>$this</code>
-      <code>$this</code>
-      <code>$this</code>
+      <code><![CDATA[$container]]></code>
+      <code><![CDATA[$this]]></code>
+      <code><![CDATA[$this]]></code>
+      <code><![CDATA[$this]]></code>
     </LessSpecificReturnStatement>
     <MethodSignatureMustProvideReturnType>
-      <code>getIterator</code>
-      <code>offsetExists</code>
-      <code>offsetGet</code>
-      <code>offsetSet</code>
-      <code>offsetUnset</code>
+      <code><![CDATA[getIterator]]></code>
+      <code><![CDATA[offsetExists]]></code>
+      <code><![CDATA[offsetGet]]></code>
+      <code><![CDATA[offsetSet]]></code>
+      <code><![CDATA[offsetUnset]]></code>
     </MethodSignatureMustProvideReturnType>
     <MixedArgument>
-      <code>$container</code>
+      <code><![CDATA[$container]]></code>
       <code><![CDATA[$metadata['EXPIRE_HOPS_KEYS']]]></code>
       <code><![CDATA[$metadata['EXPIRE_KEYS']]]></code>
-      <code>$value</code>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$metadata['EXPIRE_HOPS']['hops']]]></code>
@@ -44,11 +44,11 @@
       <code><![CDATA[$metadata['EXPIRE_HOPS_KEYS'][$key]['ts']]]></code>
       <code><![CDATA[$metadata['EXPIRE_KEYS'][$key]]]></code>
       <code><![CDATA[$metadata['EXPIRE_KEYS'][$key]]]></code>
-      <code>$storage[$name][$key]</code>
-      <code>$storage[$name][$key]</code>
-      <code>$storage[$name][$key]</code>
-      <code>$storage[$name][$key]</code>
-      <code>$storage[$name][$key]</code>
+      <code><![CDATA[$storage[$name][$key]]]></code>
+      <code><![CDATA[$storage[$name][$key]]]></code>
+      <code><![CDATA[$storage[$name][$key]]]></code>
+      <code><![CDATA[$storage[$name][$key]]]></code>
+      <code><![CDATA[$storage[$name][$key]]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$metadata['EXPIRE_HOPS']['hops']]]></code>
@@ -63,19 +63,19 @@
       <code><![CDATA[$metadata['EXPIRE_HOPS_KEYS'][$key]['ts']]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code>$container</code>
-      <code>$container</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
+      <code><![CDATA[$container]]></code>
+      <code><![CDATA[$container]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
       <code><![CDATA[$metadata['EXPIRE_HOPS']['hops']]]></code>
       <code><![CDATA[$metadata['EXPIRE_HOPS_KEYS'][$key]['hops']]]></code>
       <code><![CDATA[$metadata['EXPIRE_HOPS_KEYS'][$key]['hops']]]></code>
-      <code>$old</code>
-      <code>$storage[$name][$offset]</code>
+      <code><![CDATA[$old]]></code>
+      <code><![CDATA[$storage[$name][$offset]]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>exchangeArray</code>
-      <code>getArrayCopy</code>
+      <code><![CDATA[exchangeArray]]></code>
+      <code><![CDATA[getArrayCopy]]></code>
     </MixedInferredReturnType>
     <MixedOperand>
       <code><![CDATA[$metadata['EXPIRE_HOPS']['hops']]]></code>
@@ -85,43 +85,43 @@
     <MixedReturnStatement>
       <code><![CDATA[$container instanceof ArrayObject ? $container->getArrayCopy() : $container]]></code>
       <code><![CDATA[$container instanceof ArrayObject ? $container->getArrayCopy() : $container]]></code>
-      <code>$old</code>
-      <code>$old</code>
+      <code><![CDATA[$old]]></code>
+      <code><![CDATA[$old]]></code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$old->getArrayCopy()]]></code>
-      <code>getIterator</code>
-      <code>new ArrayIterator($container)</code>
+      <code><![CDATA[getIterator]]></code>
+      <code><![CDATA[new ArrayIterator($container)]]></code>
     </MixedReturnTypeCoercion>
     <MoreSpecificReturnType>
-      <code>Container</code>
-      <code>Container</code>
-      <code>Container</code>
+      <code><![CDATA[Container]]></code>
+      <code><![CDATA[Container]]></code>
+      <code><![CDATA[Container]]></code>
     </MoreSpecificReturnType>
     <ParamNameMismatch>
-      <code>$input</code>
-      <code>$offset</code>
+      <code><![CDATA[$input]]></code>
+      <code><![CDATA[$key]]></code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$name</code>
-      <code>$storage</code>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$storage]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
-      <code>$storage[$name]</code>
+      <code><![CDATA[$storage[$name]]]></code>
       <code><![CDATA[$storage[$this->getName()]]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyNullArrayAssignment>
-      <code>$storage[$name]</code>
+      <code><![CDATA[$storage[$name]]]></code>
     </PossiblyNullArrayAssignment>
     <PossiblyNullPropertyAssignmentValue>
-      <code>$name</code>
+      <code><![CDATA[$name]]></code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyNullReference>
-      <code>$storage</code>
-      <code>$storage</code>
-      <code>$storage</code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
@@ -129,21 +129,21 @@
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
     <PropertyNotSetInConstructor>
-      <code>$manager</code>
-      <code>AbstractContainer</code>
-      <code>AbstractContainer</code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[AbstractContainer]]></code>
+      <code><![CDATA[AbstractContainer]]></code>
     </PropertyNotSetInConstructor>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[(null !== $key)
             && is_array($metadata)]]></code>
       <code><![CDATA[(null !== $key)
             && is_array($metadata)]]></code>
-      <code>is_array($vars)</code>
-      <code>is_array($vars)</code>
+      <code><![CDATA[is_array($vars)]]></code>
+      <code><![CDATA[is_array($vars)]]></code>
       <code><![CDATA[is_scalar($vars) && null !== $vars]]></code>
-      <code>null !== $key</code>
-      <code>null !== $key</code>
-      <code>null !== $vars</code>
+      <code><![CDATA[null !== $key]]></code>
+      <code><![CDATA[null !== $key]]></code>
+      <code><![CDATA[null !== $vars]]></code>
     </RedundantConditionGivenDocblockType>
     <TooManyArguments>
       <code><![CDATA[static fn() => $ts]]></code>
@@ -156,78 +156,78 @@
       <code><![CDATA[new $this->defaultStorageClass()]]></code>
     </MixedMethodCall>
     <PropertyNotSetInConstructor>
-      <code>$saveHandler</code>
+      <code><![CDATA[$saveHandler]]></code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/AbstractValidatorChain.php">
     <DeprecatedClass>
-      <code>AbstractValidatorChainEM3</code>
+      <code><![CDATA[AbstractValidatorChainEM3]]></code>
     </DeprecatedClass>
   </file>
   <file src="src/Config/SessionConfig.php">
     <DocblockTypeContradiction>
-      <code>! is_numeric($hashBitsPerCharacter)</code>
-      <code>! is_numeric($sidBitsPerCharacter)</code>
+      <code><![CDATA[! is_numeric($hashBitsPerCharacter)]]></code>
+      <code><![CDATA[! is_numeric($sidBitsPerCharacter)]]></code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch>
-      <code>SessionConfig</code>
+      <code><![CDATA[SessionConfig]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument>
       <code><![CDATA[[$this, 'handleError']]]></code>
       <code><![CDATA[[$this, 'handleError']]]></code>
     </InvalidArgument>
     <InvalidNullableReturnType>
-      <code>SessionConfig</code>
+      <code><![CDATA[SessionConfig]]></code>
     </InvalidNullableReturnType>
     <MissingConstructor>
-      <code>$serializeHandler</code>
-      <code>$validHashFunctions</code>
+      <code><![CDATA[$serializeHandler]]></code>
+      <code><![CDATA[$validHashFunctions]]></code>
     </MissingConstructor>
     <MixedArgument>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$knownHandlers</code>
+      <code><![CDATA[$knownHandlers]]></code>
     </MixedArgumentTypeCoercion>
     <MixedInferredReturnType>
-      <code>false|string</code>
+      <code><![CDATA[false|string]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$callback($module)</code>
-      <code>$callback()</code>
+      <code><![CDATA[$callback($module)]]></code>
+      <code><![CDATA[$callback()]]></code>
     </MixedReturnStatement>
     <PossiblyFalsePropertyAssignmentValue>
-      <code>false</code>
-      <code>false</code>
+      <code><![CDATA[false]]></code>
+      <code><![CDATA[false]]></code>
     </PossiblyFalsePropertyAssignmentValue>
     <RedundantCast>
-      <code>(string) $iniGet</code>
+      <code><![CDATA[(string) $iniGet]]></code>
     </RedundantCast>
     <RedundantCastGivenDocblockType>
-      <code>(int) $hashBitsPerCharacter</code>
-      <code>(int) $sidBitsPerCharacter</code>
-      <code>(string) $cacheLimiter</code>
-      <code>(string) $serializeHandler</code>
-      <code>(string) $serializeHandler</code>
+      <code><![CDATA[(int) $hashBitsPerCharacter]]></code>
+      <code><![CDATA[(int) $sidBitsPerCharacter]]></code>
+      <code><![CDATA[(string) $cacheLimiter]]></code>
+      <code><![CDATA[(string) $serializeHandler]]></code>
+      <code><![CDATA[(string) $serializeHandler]]></code>
     </RedundantCastGivenDocblockType>
     <UnusedVariable>
-      <code>$prefix</code>
+      <code><![CDATA[$prefix]]></code>
     </UnusedVariable>
   </file>
   <file src="src/Config/StandardConfig.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_array($options) && ! $options instanceof Traversable]]></code>
-      <code>! is_numeric($sidLength)</code>
-      <code>is_numeric($cacheExpire)</code>
-      <code>is_numeric($cookieLifetime)</code>
-      <code>is_numeric($entropyLength)</code>
-      <code>is_numeric($gcDivisor)</code>
-      <code>is_numeric($gcMaxlifetime)</code>
-      <code>is_numeric($gcProbability)</code>
-      <code>is_numeric($hashBitsPerCharacter)</code>
-      <code>is_numeric($rememberMeSeconds)</code>
-      <code>is_numeric($sidBitsPerCharacter)</code>
-      <code>is_string($cookieDomain)</code>
+      <code><![CDATA[! is_numeric($sidLength)]]></code>
+      <code><![CDATA[is_numeric($cacheExpire)]]></code>
+      <code><![CDATA[is_numeric($cookieLifetime)]]></code>
+      <code><![CDATA[is_numeric($entropyLength)]]></code>
+      <code><![CDATA[is_numeric($gcDivisor)]]></code>
+      <code><![CDATA[is_numeric($gcMaxlifetime)]]></code>
+      <code><![CDATA[is_numeric($gcProbability)]]></code>
+      <code><![CDATA[is_numeric($hashBitsPerCharacter)]]></code>
+      <code><![CDATA[is_numeric($rememberMeSeconds)]]></code>
+      <code><![CDATA[is_numeric($sidBitsPerCharacter)]]></code>
+      <code><![CDATA[is_string($cookieDomain)]]></code>
       <code><![CDATA[null === $this->cookieDomain]]></code>
       <code><![CDATA[null === $this->cookieHttpOnly]]></code>
       <code><![CDATA[null === $this->cookieLifetime]]></code>
@@ -240,58 +240,58 @@
       <code><![CDATA[null === $this->useCookies]]></code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>StandardConfig</code>
-      <code>bool|string</code>
-      <code>bool|string</code>
-      <code>null|string</code>
-      <code>string|null</code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[StandardConfig]]></code>
+      <code><![CDATA[bool|string]]></code>
+      <code><![CDATA[bool|string]]></code>
+      <code><![CDATA[null|string]]></code>
+      <code><![CDATA[string|null]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument>
-      <code>HostnameValidator::ALLOW_ALL</code>
+      <code><![CDATA[HostnameValidator::ALLOW_ALL]]></code>
     </InvalidArgument>
     <InvalidReturnType>
-      <code>mixed</code>
+      <code><![CDATA[mixed]]></code>
     </InvalidReturnType>
     <LessSpecificImplementedReturnType>
-      <code>array</code>
+      <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
     <MissingConstructor>
-      <code>$cookieDomain</code>
-      <code>$cookieDomain</code>
-      <code>$cookieHttpOnly</code>
-      <code>$cookieHttpOnly</code>
-      <code>$cookieLifetime</code>
-      <code>$cookieLifetime</code>
-      <code>$cookiePath</code>
-      <code>$cookiePath</code>
-      <code>$cookieSameSite</code>
-      <code>$cookieSameSite</code>
-      <code>$cookieSecure</code>
-      <code>$cookieSecure</code>
-      <code>$name</code>
-      <code>$name</code>
-      <code>$rememberMeSeconds</code>
-      <code>$savePath</code>
-      <code>$savePath</code>
-      <code>$useCookies</code>
-      <code>$useCookies</code>
+      <code><![CDATA[$cookieDomain]]></code>
+      <code><![CDATA[$cookieDomain]]></code>
+      <code><![CDATA[$cookieHttpOnly]]></code>
+      <code><![CDATA[$cookieHttpOnly]]></code>
+      <code><![CDATA[$cookieLifetime]]></code>
+      <code><![CDATA[$cookieLifetime]]></code>
+      <code><![CDATA[$cookiePath]]></code>
+      <code><![CDATA[$cookiePath]]></code>
+      <code><![CDATA[$cookieSameSite]]></code>
+      <code><![CDATA[$cookieSameSite]]></code>
+      <code><![CDATA[$cookieSecure]]></code>
+      <code><![CDATA[$cookieSecure]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$rememberMeSeconds]]></code>
+      <code><![CDATA[$savePath]]></code>
+      <code><![CDATA[$savePath]]></code>
+      <code><![CDATA[$useCookies]]></code>
+      <code><![CDATA[$useCookies]]></code>
     </MissingConstructor>
     <MixedArgument>
-      <code>$key</code>
-      <code>$key</code>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$key]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$key</code>
+      <code><![CDATA[$key]]></code>
       <code><![CDATA[$this->cookieDomain]]></code>
       <code><![CDATA[$this->cookieHttpOnly]]></code>
       <code><![CDATA[$this->cookieLifetime]]></code>
@@ -302,30 +302,30 @@
       <code><![CDATA[$this->rememberMeSeconds]]></code>
       <code><![CDATA[$this->savePath]]></code>
       <code><![CDATA[$this->useCookies]]></code>
-      <code>$value</code>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>bool</code>
-      <code>bool|string</code>
-      <code>bool|string</code>
-      <code>int</code>
-      <code>int</code>
-      <code>int</code>
-      <code>int</code>
-      <code>int</code>
-      <code>null|string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string|null</code>
+      <code><![CDATA[bool]]></code>
+      <code><![CDATA[bool|string]]></code>
+      <code><![CDATA[bool|string]]></code>
+      <code><![CDATA[int]]></code>
+      <code><![CDATA[int]]></code>
+      <code><![CDATA[int]]></code>
+      <code><![CDATA[int]]></code>
+      <code><![CDATA[int]]></code>
+      <code><![CDATA[null|string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string|null]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->cookieDomain]]></code>
@@ -366,49 +366,49 @@
       <code><![CDATA[str_replace('_', ' ', $key)]]></code>
     </PossiblyInvalidCast>
     <RedundantCastGivenDocblockType>
-      <code>(bool) $cookieHttpOnly</code>
-      <code>(bool) $cookieSecure</code>
-      <code>(bool) $useCookies</code>
-      <code>(int) $cacheExpire</code>
-      <code>(int) $cookieLifetime</code>
-      <code>(int) $gcDivisor</code>
-      <code>(int) $gcMaxlifetime</code>
-      <code>(int) $gcProbability</code>
-      <code>(int) $hashBitsPerCharacter</code>
-      <code>(int) $rememberMeSeconds</code>
-      <code>(int) $sidBitsPerCharacter</code>
-      <code>(int) $sidLength</code>
-      <code>(string) $cookiePath</code>
-      <code>(string) $cookieSameSite</code>
-      <code>(string) $name</code>
+      <code><![CDATA[(bool) $cookieHttpOnly]]></code>
+      <code><![CDATA[(bool) $cookieSecure]]></code>
+      <code><![CDATA[(bool) $useCookies]]></code>
+      <code><![CDATA[(int) $cacheExpire]]></code>
+      <code><![CDATA[(int) $cookieLifetime]]></code>
+      <code><![CDATA[(int) $gcDivisor]]></code>
+      <code><![CDATA[(int) $gcMaxlifetime]]></code>
+      <code><![CDATA[(int) $gcProbability]]></code>
+      <code><![CDATA[(int) $hashBitsPerCharacter]]></code>
+      <code><![CDATA[(int) $rememberMeSeconds]]></code>
+      <code><![CDATA[(int) $sidBitsPerCharacter]]></code>
+      <code><![CDATA[(int) $sidLength]]></code>
+      <code><![CDATA[(string) $cookiePath]]></code>
+      <code><![CDATA[(string) $cookieSameSite]]></code>
+      <code><![CDATA[(string) $name]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/ConfigProvider.php">
     <UndefinedClass>
-      <code>ConfigInterface</code>
-      <code>StorageInterface</code>
-      <code>\Zend\Session\ManagerInterface</code>
-      <code>\Zend\Session\SessionManager</code>
+      <code><![CDATA[ConfigInterface]]></code>
+      <code><![CDATA[StorageInterface]]></code>
+      <code><![CDATA[\Zend\Session\ManagerInterface]]></code>
+      <code><![CDATA[\Zend\Session\SessionManager]]></code>
     </UndefinedClass>
   </file>
   <file src="src/Container.php">
     <MethodSignatureMustProvideReturnType>
-      <code>offsetGet</code>
+      <code><![CDATA[offsetGet]]></code>
     </MethodSignatureMustProvideReturnType>
     <MixedArrayAccess>
-      <code>$storage[$name][$key]</code>
+      <code><![CDATA[$storage[$name][$key]]]></code>
     </MixedArrayAccess>
     <PropertyNotSetInConstructor>
-      <code>Container</code>
+      <code><![CDATA[Container]]></code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/SaveHandler/Cache.php">
     <ImplementedReturnTypeMismatch>
-      <code>bool</code>
+      <code><![CDATA[bool]]></code>
     </ImplementedReturnTypeMismatch>
     <PropertyNotSetInConstructor>
-      <code>$sessionName</code>
-      <code>$sessionSavePath</code>
+      <code><![CDATA[$sessionName]]></code>
+      <code><![CDATA[$sessionSavePath]]></code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $this->getCacheStorage()->removeItem($id)]]></code>
@@ -416,7 +416,7 @@
   </file>
   <file src="src/SaveHandler/DbTableGateway.php">
     <ImplementedReturnTypeMismatch>
-      <code>true</code>
+      <code><![CDATA[true]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[ini_get('session.gc_maxlifetime')]]></code>
@@ -431,11 +431,11 @@
         )]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code>true</code>
+      <code><![CDATA[true]]></code>
     </InvalidReturnType>
     <MixedAssignment>
-      <code>$row</code>
-      <code>$rows</code>
+      <code><![CDATA[$row]]></code>
+      <code><![CDATA[$rows]]></code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$row->{$this->options->getModifiedColumn()}]]></code>
@@ -446,28 +446,28 @@
       <code><![CDATA[$row->{$this->options->getModifiedColumn()}]]></code>
     </MixedPropertyFetch>
     <PropertyNotSetInConstructor>
-      <code>$lifetime</code>
-      <code>$sessionName</code>
-      <code>$sessionSavePath</code>
+      <code><![CDATA[$lifetime]]></code>
+      <code><![CDATA[$sessionName]]></code>
+      <code><![CDATA[$sessionSavePath]]></code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
-      <code>(string) $data</code>
+      <code><![CDATA[(string) $data]]></code>
     </RedundantCastGivenDocblockType>
     <UndefinedInterfaceMethod>
-      <code>current</code>
-      <code>current</code>
+      <code><![CDATA[current]]></code>
+      <code><![CDATA[current]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/SaveHandler/DbTableGatewayOptions.php">
     <MissingTemplateParam>
-      <code>DbTableGatewayOptions</code>
+      <code><![CDATA[DbTableGatewayOptions]]></code>
     </MissingTemplateParam>
     <RedundantCastGivenDocblockType>
-      <code>(string) $dataColumn</code>
-      <code>(string) $idColumn</code>
-      <code>(string) $lifetimeColumn</code>
-      <code>(string) $modifiedColumn</code>
-      <code>(string) $nameColumn</code>
+      <code><![CDATA[(string) $dataColumn]]></code>
+      <code><![CDATA[(string) $idColumn]]></code>
+      <code><![CDATA[(string) $lifetimeColumn]]></code>
+      <code><![CDATA[(string) $modifiedColumn]]></code>
+      <code><![CDATA[(string) $nameColumn]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/SaveHandler/MongoDB.php">
@@ -476,7 +476,7 @@
       <code><![CDATA[null === ($database = $options->getDatabase())]]></code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch>
-      <code>bool</code>
+      <code><![CDATA[bool]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument>
       <code><![CDATA[$this->options->getSaveOptions()]]></code>
@@ -487,17 +487,17 @@
       <code><![CDATA[(string) $session[$this->options->getModifiedField()]]]></code>
     </InvalidOperand>
     <MixedAssignment>
-      <code>$timestamp</code>
-      <code>$timestamp</code>
+      <code><![CDATA[$timestamp]]></code>
+      <code><![CDATA[$timestamp]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>string</code>
+      <code><![CDATA[string]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
-      <code>getData</code>
+      <code><![CDATA[getData]]></code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$timestamp</code>
+      <code><![CDATA[$timestamp]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$session[$this->options->getDataField()]->getData()]]></code>
@@ -508,12 +508,12 @@
       <code><![CDATA[$session[$this->options->getModifiedField()]]]></code>
     </PossiblyInvalidArrayAccess>
     <PropertyNotSetInConstructor>
-      <code>$lifetime</code>
-      <code>$mongoCollection</code>
-      <code>$sessionName</code>
+      <code><![CDATA[$lifetime]]></code>
+      <code><![CDATA[$mongoCollection]]></code>
+      <code><![CDATA[$sessionName]]></code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
-      <code>(string) $data</code>
+      <code><![CDATA[(string) $data]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/SaveHandler/MongoDBOptions.php">
@@ -522,65 +522,65 @@
       <code><![CDATA[$this->saveOptions === ['w' => 1]]]></code>
     </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue>
-      <code>$saveOptions</code>
+      <code><![CDATA[$saveOptions]]></code>
       <code><![CDATA[['safe' => true]]]></code>
       <code><![CDATA[['w' => 1]]]></code>
     </InvalidPropertyAssignmentValue>
     <MissingParamType>
-      <code>$options</code>
+      <code><![CDATA[$options]]></code>
     </MissingParamType>
     <MissingReturnType>
-      <code>setUseExpireAfterSecondsIndex</code>
+      <code><![CDATA[setUseExpireAfterSecondsIndex]]></code>
     </MissingReturnType>
     <MissingTemplateParam>
-      <code>MongoDBOptions</code>
+      <code><![CDATA[MongoDBOptions]]></code>
     </MissingTemplateParam>
     <MixedArgument>
-      <code>$options</code>
+      <code><![CDATA[$options]]></code>
     </MixedArgument>
     <PropertyNotSetInConstructor>
-      <code>$collection</code>
-      <code>$database</code>
+      <code><![CDATA[$collection]]></code>
+      <code><![CDATA[$database]]></code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
-      <code>(bool) $useExpireAfterSecondsIndex</code>
-      <code>(string) $collection</code>
-      <code>(string) $dataField</code>
-      <code>(string) $database</code>
-      <code>(string) $lifetimeField</code>
-      <code>(string) $modifiedField</code>
-      <code>(string) $nameField</code>
+      <code><![CDATA[(bool) $useExpireAfterSecondsIndex]]></code>
+      <code><![CDATA[(string) $collection]]></code>
+      <code><![CDATA[(string) $dataField]]></code>
+      <code><![CDATA[(string) $database]]></code>
+      <code><![CDATA[(string) $lifetimeField]]></code>
+      <code><![CDATA[(string) $modifiedField]]></code>
+      <code><![CDATA[(string) $nameField]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Service/ContainerAbstractServiceFactory.php">
     <DeprecatedInterface>
-      <code>ContainerAbstractServiceFactory</code>
+      <code><![CDATA[ContainerAbstractServiceFactory]]></code>
     </DeprecatedInterface>
     <MissingConstructor>
-      <code>$config</code>
-      <code>$sessionManager</code>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$sessionManager]]></code>
     </MissingConstructor>
     <MixedArgument>
-      <code>$config</code>
+      <code><![CDATA[$config]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$config[$this->configKey]]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code>$config</code>
-      <code>$config</code>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$config]]></code>
       <code><![CDATA[$this->sessionManager]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>null|ManagerInterface</code>
+      <code><![CDATA[null|ManagerInterface]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->sessionManager]]></code>
       <code><![CDATA[$this->sessionManager]]></code>
     </MixedReturnStatement>
     <ParamNameMismatch>
-      <code>$container</code>
-      <code>$container</code>
+      <code><![CDATA[$container]]></code>
+      <code><![CDATA[$container]]></code>
     </ParamNameMismatch>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[$this->sessionManager !== null]]></code>
@@ -589,189 +589,192 @@
   </file>
   <file src="src/Service/SessionConfigFactory.php">
     <DeprecatedInterface>
-      <code>SessionConfigFactory</code>
+      <code><![CDATA[SessionConfigFactory]]></code>
     </DeprecatedInterface>
     <MixedArgument>
-      <code>$config</code>
+      <code><![CDATA[$config]]></code>
       <code><![CDATA[$config['config_class']]]></code>
       <code><![CDATA[$config['config_class']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$config</code>
+      <code><![CDATA[$config]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>new $class()</code>
+      <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>
     <ParamNameMismatch>
-      <code>$services</code>
+      <code><![CDATA[$services]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Service/SessionManagerFactory.php">
     <DeprecatedInterface>
-      <code>SessionManagerFactory</code>
+      <code><![CDATA[SessionManagerFactory]]></code>
     </DeprecatedInterface>
     <LessSpecificReturnStatement>
-      <code>$manager</code>
+      <code><![CDATA[$manager]]></code>
     </LessSpecificReturnStatement>
     <MixedAssignment>
-      <code>$config</code>
-      <code>$configService</code>
-      <code>$options</code>
-      <code>$saveHandler</code>
-      <code>$storage</code>
-      <code>$validators</code>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$configService]]></code>
+      <code><![CDATA[$options]]></code>
+      <code><![CDATA[$saveHandler]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$validators]]></code>
     </MixedAssignment>
     <MoreSpecificReturnType>
-      <code>SessionManager</code>
+      <code><![CDATA[SessionManager]]></code>
     </MoreSpecificReturnType>
     <ParamNameMismatch>
-      <code>$services</code>
+      <code><![CDATA[$services]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Service/StorageFactory.php">
     <DeprecatedInterface>
-      <code>StorageFactory</code>
+      <code><![CDATA[StorageFactory]]></code>
     </DeprecatedInterface>
     <MixedArgument>
-      <code>$options</code>
-      <code>$type</code>
+      <code><![CDATA[$options]]></code>
+      <code><![CDATA[$type]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$config</code>
-      <code>$options</code>
-      <code>$type</code>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$options]]></code>
+      <code><![CDATA[$type]]></code>
     </MixedAssignment>
     <ParamNameMismatch>
-      <code>$services</code>
+      <code><![CDATA[$services]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/SessionManager.php">
     <DocblockTypeContradiction>
-      <code>$_SESSION !== $storage</code>
+      <code><![CDATA[$_SESSION !== $storage]]></code>
       <code><![CDATA[null === $this->name]]></code>
       <code><![CDATA[null === $this->validatorChain]]></code>
     </DocblockTypeContradiction>
     <MissingClosureParamType>
-      <code>$test</code>
+      <code><![CDATA[$test]]></code>
     </MissingClosureParamType>
     <MissingReturnType>
-      <code>initializeValidatorChain</code>
+      <code><![CDATA[initializeValidatorChain]]></code>
     </MissingReturnType>
     <MixedArgument>
-      <code>$validator</code>
+      <code><![CDATA[$validator]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$sid</code>
-      <code>$validator</code>
-      <code>$validatorValues</code>
+      <code><![CDATA[$sid]]></code>
+      <code><![CDATA[$validator]]></code>
+      <code><![CDATA[$validatorValues]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>new $validator(null)</code>
+      <code><![CDATA[new $validator(null)]]></code>
     </MixedMethodCall>
     <MoreSpecificImplementedParamType>
-      <code>$id</code>
+      <code><![CDATA[$id]]></code>
     </MoreSpecificImplementedParamType>
     <NoValue>
-      <code>$oldSessionData</code>
+      <code><![CDATA[$oldSessionData]]></code>
     </NoValue>
+    <PossiblyNullOperand>
+      <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
+    </PossiblyNullOperand>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
     <PropertyNotSetInConstructor>
-      <code>$name</code>
-      <code>$validatorChain</code>
-      <code>SessionManager</code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$validatorChain]]></code>
+      <code><![CDATA[SessionManager]]></code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $config->getCookieHttpOnly()]]></code>
       <code><![CDATA[(bool) $config->getCookieSecure()]]></code>
-      <code>(bool) $deleteOldSession</code>
+      <code><![CDATA[(bool) $deleteOldSession]]></code>
     </RedundantCastGivenDocblockType>
     <RedundantCondition>
       <code><![CDATA[! empty($oldSessionData) && is_array($oldSessionData)]]></code>
-      <code>is_array($oldSessionData)</code>
+      <code><![CDATA[is_array($oldSessionData)]]></code>
     </RedundantCondition>
     <TypeDoesNotContainType>
-      <code>$oldSessionData instanceof Traversable</code>
+      <code><![CDATA[$oldSessionData instanceof Traversable]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Storage/AbstractSessionArrayStorage.php">
     <InvalidReturnStatement>
-      <code>$_SESSION</code>
-      <code>$this</code>
-      <code>$this</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>new ArrayIterator($_SESSION)</code>
+      <code><![CDATA[$_SESSION]]></code>
+      <code><![CDATA[$this]]></code>
+      <code><![CDATA[$this]]></code>
+      <code><![CDATA[$values]]></code>
+      <code><![CDATA[$values]]></code>
+      <code><![CDATA[new ArrayIterator($_SESSION)]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code>SessionStorage</code>
-      <code>SessionStorage</code>
-      <code>array</code>
+      <code><![CDATA[SessionStorage]]></code>
+      <code><![CDATA[SessionStorage]]></code>
+      <code><![CDATA[array]]></code>
       <code><![CDATA[array<TKey, TValue>]]></code>
-      <code>getIterator</code>
+      <code><![CDATA[getIterator]]></code>
     </InvalidReturnType>
     <InvalidScalarArgument>
-      <code>$_SESSION</code>
+      <code><![CDATA[$_SESSION]]></code>
     </InvalidScalarArgument>
     <MethodSignatureMustProvideReturnType>
-      <code>serialize</code>
-      <code>unserialize</code>
+      <code><![CDATA[serialize]]></code>
+      <code><![CDATA[unserialize]]></code>
     </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code><![CDATA[$_SESSION['__Laminas']]]></code>
       <code><![CDATA[$_SESSION['__Laminas'][$key]]]></code>
-      <code>$locks</code>
-      <code>$locks</code>
-      <code>$locks</code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$locks]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['__Laminas'][$key]]]></code>
     </MixedArrayAccess>
     <MixedArrayOffset>
-      <code>$_SESSION[$key]</code>
-      <code>$_SESSION[$key]</code>
-      <code>$_SESSION[$offset]</code>
-      <code>$_SESSION[$offset]</code>
+      <code><![CDATA[$_SESSION[$key]]]></code>
+      <code><![CDATA[$_SESSION[$key]]]></code>
+      <code><![CDATA[$_SESSION[$offset]]]></code>
+      <code><![CDATA[$_SESSION[$offset]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code>$_SESSION[$offset]</code>
+      <code><![CDATA[$_SESSION[$offset]]]></code>
       <code><![CDATA[$_SESSION['__Laminas'][$key]]]></code>
-      <code>$locks</code>
-      <code>$locks</code>
-      <code>$readOnly</code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$readOnly]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>bool</code>
-      <code>float</code>
+      <code><![CDATA[bool]]></code>
+      <code><![CDATA[float]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->getMetadata('_READONLY')]]></code>
       <code><![CDATA[$this->getMetadata('_REQUEST_ACCESS_TIME')]]></code>
     </MixedReturnStatement>
     <ParamNameMismatch>
-      <code>$metaData</code>
+      <code><![CDATA[$metaData]]></code>
     </ParamNameMismatch>
     <PossiblyInvalidArgument>
-      <code>$key</code>
+      <code><![CDATA[$key]]></code>
     </PossiblyInvalidArgument>
     <RedundantCondition>
-      <code>$_SESSION instanceof ArrayObject</code>
-      <code>$locks</code>
+      <code><![CDATA[$_SESSION instanceof ArrayObject]]></code>
+      <code><![CDATA[$locks]]></code>
     </RedundantCondition>
     <TypeDoesNotContainType>
-      <code>is_object($input)</code>
+      <code><![CDATA[is_object($input)]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Storage/ArrayStorage.php">
     <ArgumentTypeCoercion>
-      <code>$flags</code>
-      <code>$iteratorClass</code>
+      <code><![CDATA[$flags]]></code>
+      <code><![CDATA[$iteratorClass]]></code>
     </ArgumentTypeCoercion>
     <InvalidArgument>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$key</code>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$key]]></code>
       <code><![CDATA['__Laminas']]></code>
       <code><![CDATA['__Laminas']]></code>
       <code><![CDATA['__Laminas']]></code>
@@ -786,19 +789,19 @@
       <code><![CDATA['__Laminas']]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$locks</code>
-      <code>$locks</code>
-      <code>$locks</code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$locks]]></code>
       <code><![CDATA[$this['__Laminas']]]></code>
       <code><![CDATA[$this['__Laminas'][$key]]]></code>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$this['__Laminas']]]></code>
       <code><![CDATA[$this['__Laminas']]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code>$array[$key]</code>
+      <code><![CDATA[$array[$key]]]></code>
       <code><![CDATA[$this['__Laminas'][$key]]]></code>
       <code><![CDATA[$this['__Laminas'][$key]]]></code>
     </MixedArrayAccess>
@@ -808,27 +811,26 @@
       <code><![CDATA[$this['__Laminas'][$key]]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code>$array</code>
-      <code>$locks</code>
-      <code>$locks</code>
-      <code>$readOnly</code>
+      <code><![CDATA[$array]]></code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$locks]]></code>
+      <code><![CDATA[$readOnly]]></code>
       <code><![CDATA[$this['__Laminas']]]></code>
       <code><![CDATA[$this['__Laminas'][$key]]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>bool</code>
-      <code>float</code>
+      <code><![CDATA[bool]]></code>
+      <code><![CDATA[float]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->getMetadata('_READONLY')]]></code>
       <code><![CDATA[$this->getMetadata('_REQUEST_ACCESS_TIME')]]></code>
     </MixedReturnStatement>
     <ParamNameMismatch>
-      <code>$metaData</code>
-      <code>$offset</code>
+      <code><![CDATA[$metaData]]></code>
     </ParamNameMismatch>
     <PossiblyInvalidArgument>
-      <code>$key</code>
+      <code><![CDATA[$key]]></code>
     </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$this['__Laminas']]]></code>
@@ -837,49 +839,49 @@
       <code><![CDATA[$this['__Laminas'][$key]]]></code>
     </PossiblyNullArrayAccess>
     <PropertyNotSetInConstructor>
-      <code>ArrayStorage</code>
+      <code><![CDATA[ArrayStorage]]></code>
     </PropertyNotSetInConstructor>
     <RedundantCondition>
-      <code>$locks</code>
+      <code><![CDATA[$locks]]></code>
     </RedundantCondition>
   </file>
   <file src="src/Storage/Factory.php">
     <DocblockTypeContradiction>
-      <code>is_array($options)</code>
-      <code>is_string($type)</code>
+      <code><![CDATA[is_array($options)]]></code>
+      <code><![CDATA[is_string($type)]]></code>
     </DocblockTypeContradiction>
     <InvalidStringClass>
-      <code>new $type($input)</code>
-      <code>new $type($input, $flags, $iteratorClass)</code>
+      <code><![CDATA[new $type($input)]]></code>
+      <code><![CDATA[new $type($input, $flags, $iteratorClass)]]></code>
     </InvalidStringClass>
     <LessSpecificReturnStatement>
-      <code>new $type($input)</code>
-      <code>new $type($input, $flags, $iteratorClass)</code>
-      <code>new $type($options)</code>
+      <code><![CDATA[new $type($input)]]></code>
+      <code><![CDATA[new $type($input, $flags, $iteratorClass)]]></code>
+      <code><![CDATA[new $type($options)]]></code>
     </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$options['iterator_class']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$flags</code>
-      <code>$input</code>
+      <code><![CDATA[$flags]]></code>
+      <code><![CDATA[$input]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>new $type($options)</code>
+      <code><![CDATA[new $type($options)]]></code>
     </MixedMethodCall>
     <MoreSpecificReturnType>
-      <code>AbstractSessionArrayStorage</code>
-      <code>ArrayStorage</code>
-      <code>StorageInterface</code>
+      <code><![CDATA[AbstractSessionArrayStorage]]></code>
+      <code><![CDATA[ArrayStorage]]></code>
+      <code><![CDATA[StorageInterface]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="src/Storage/SessionArrayStorage.php">
     <MethodSignatureMustProvideReturnType>
-      <code>offsetGet</code>
+      <code><![CDATA[offsetGet]]></code>
     </MethodSignatureMustProvideReturnType>
     <MixedArrayOffset>
-      <code>$_SESSION[$key]</code>
-      <code>$_SESSION[$key]</code>
+      <code><![CDATA[$_SESSION[$key]]]></code>
+      <code><![CDATA[$_SESSION[$key]]]></code>
     </MixedArrayOffset>
   </file>
   <file src="src/Storage/SessionStorage.php">
@@ -889,74 +891,77 @@
       <code><![CDATA['_IMMUTABLE']]></code>
     </InvalidArgument>
     <PropertyNotSetInConstructor>
-      <code>SessionStorage</code>
+      <code><![CDATA[SessionStorage]]></code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(array) $this->getArrayCopy()]]></code>
     </RedundantCastGivenDocblockType>
     <RedundantCondition>
-      <code>$_SESSION !== $this</code>
-      <code>$_SESSION !== $this</code>
-      <code>$_SESSION instanceof ArrayObject</code>
+      <code><![CDATA[$_SESSION !== $this]]></code>
+      <code><![CDATA[$_SESSION !== $this]]></code>
+      <code><![CDATA[$_SESSION instanceof ArrayObject]]></code>
     </RedundantCondition>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[$this['_IMMUTABLE']]]></code>
+    </RiskyTruthyFalsyComparison>
     <TypeDoesNotContainType>
-      <code>is_object($input)</code>
-      <code>is_object($input)</code>
+      <code><![CDATA[is_object($input)]]></code>
+      <code><![CDATA[is_object($input)]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Validator/AbstractValidatorChainEM3.php">
     <DeprecatedTrait>
-      <code>ValidatorChainTrait</code>
+      <code><![CDATA[ValidatorChainTrait]]></code>
     </DeprecatedTrait>
     <ImplementedReturnTypeMismatch>
-      <code>CallbackHandler</code>
+      <code><![CDATA[CallbackHandler]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidReturnStatement>
       <code><![CDATA[$this->attachValidator($eventName, $listener, $priority)]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code>CallbackHandler</code>
+      <code><![CDATA[CallbackHandler]]></code>
     </InvalidReturnType>
     <MixedAssignment>
-      <code>$data</code>
-      <code>$validator</code>
-      <code>$validators</code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$validator]]></code>
+      <code><![CDATA[$validators]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>new $validator($data)</code>
+      <code><![CDATA[new $validator($data)]]></code>
     </MixedMethodCall>
     <UndefinedDocblockClass>
-      <code>CallbackHandler</code>
+      <code><![CDATA[CallbackHandler]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/Validator/HttpUserAgent.php">
     <PossiblyNullPropertyAssignmentValue>
-      <code>$data</code>
+      <code><![CDATA[$data]]></code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="src/Validator/ValidatorChainTrait.php">
     <MixedArgumentTypeCoercion>
-      <code>$callback</code>
+      <code><![CDATA[$callback]]></code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code>$data</code>
+      <code><![CDATA[$data]]></code>
     </MixedAssignment>
     <UndefinedDocblockClass>
-      <code>CallbackHandler|callable</code>
+      <code><![CDATA[CallbackHandler|callable]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/ValidatorChain.php">
     <MixedArgumentTypeCoercion>
-      <code>$callback</code>
+      <code><![CDATA[$callback]]></code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$validator</code>
-      <code>$validators</code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$validator]]></code>
+      <code><![CDATA[$validators]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>new $validator($data)</code>
+      <code><![CDATA[new $validator($data)]]></code>
     </MixedMethodCall>
   </file>
   <file src="test/AbstractContainerTest.php">
@@ -969,8 +974,8 @@
       <code><![CDATA['InvalidArgumentException']]></code>
     </ArgumentTypeCoercion>
     <InvalidArgument>
-      <code>$handler</code>
-      <code>$saveHandler</code>
+      <code><![CDATA[$handler]]></code>
+      <code><![CDATA[$saveHandler]]></code>
       <code><![CDATA['foobar_bogus']]></code>
       <code><![CDATA['foobar_bogus']]></code>
       <code><![CDATA['foobar_bogus']]></code>
@@ -978,71 +983,53 @@
       <code><![CDATA['foobar_bogus']]></code>
       <code><![CDATA['foobar_bogus']]></code>
       <code><![CDATA['foobar_bogus']]></code>
-      <code>24</code>
-      <code>24</code>
+      <code><![CDATA[24]]></code>
+      <code><![CDATA[24]]></code>
     </InvalidArgument>
     <InvalidCast>
-      <code>$handler</code>
-      <code>$saveHandler</code>
+      <code><![CDATA[$handler]]></code>
+      <code><![CDATA[$saveHandler]]></code>
     </InvalidCast>
     <InvalidScalarArgument>
-      <code>1</code>
+      <code><![CDATA[1]]></code>
     </InvalidScalarArgument>
     <MissingClosureReturnType>
-      <code>static function (?string $module = null) {</code>
-      <code>static function (?string $module = null) {</code>
+      <code><![CDATA[static function (?string $module = null) {]]></code>
+      <code><![CDATA[static function (?string $module = null) {]]></code>
     </MissingClosureReturnType>
     <MissingReturnType>
-      <code>testCookieSameSiteAltersIniSetting</code>
-      <code>testCookieSameSiteDefaultsToIniSettings</code>
-      <code>testCookieSameSiteIsMutable</code>
+      <code><![CDATA[testCookieSameSiteAltersIniSetting]]></code>
+      <code><![CDATA[testCookieSameSiteDefaultsToIniSettings]]></code>
+      <code><![CDATA[testCookieSameSiteIsMutable]]></code>
     </MissingReturnType>
     <PossiblyNullArgument>
       <code><![CDATA[var_export($this->config->toArray(), 1)]]></code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyAssignmentValue>
-      <code>null</code>
+      <code><![CDATA[null]]></code>
     </PossiblyNullPropertyAssignmentValue>
     <RedundantCondition>
-      <code>assertFalse</code>
+      <code><![CDATA[assertFalse]]></code>
     </RedundantCondition>
-    <UnevaluatedCode>
-      <code><![CDATA[$this->config->getEntropyFile();]]></code>
-      <code><![CDATA[$this->config->getEntropyLength();]]></code>
-      <code><![CDATA[$this->config->getHashBitsPerCharacter();]]></code>
-      <code><![CDATA[$this->config->getHashFunction();]]></code>
-      <code><![CDATA[$this->config->setEntropyFile(__FILE__);]]></code>
-      <code><![CDATA[$this->config->setEntropyLength(0);]]></code>
-      <code><![CDATA[$this->config->setHashBitsPerCharacter(5);]]></code>
-      <code><![CDATA[$this->config->setHashFunction('foobar_bogus');]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-      <code><![CDATA[$this->expectDeprecation();]]></code>
-    </UnevaluatedCode>
   </file>
   <file src="test/Config/StandardConfigTest.php">
     <DeprecatedMethod>
-      <code>expectDeprecation</code>
-      <code>expectDeprecation</code>
-      <code>expectDeprecation</code>
-      <code>expectDeprecation</code>
-      <code>expectDeprecation</code>
-      <code>expectDeprecation</code>
-      <code>expectDeprecation</code>
-      <code>expectDeprecation</code>
-      <code>getEntropyFile</code>
-      <code>getEntropyLength</code>
-      <code>getHashBitsPerCharacter</code>
-      <code>getHashFunction</code>
-      <code>setEntropyFile</code>
-      <code>setEntropyLength</code>
-      <code>setHashBitsPerCharacter</code>
-      <code>setHashFunction</code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[expectDeprecation]]></code>
+      <code><![CDATA[getEntropyFile]]></code>
+      <code><![CDATA[getEntropyLength]]></code>
+      <code><![CDATA[getHashBitsPerCharacter]]></code>
+      <code><![CDATA[getHashFunction]]></code>
+      <code><![CDATA[setEntropyFile]]></code>
+      <code><![CDATA[setEntropyLength]]></code>
+      <code><![CDATA[setHashBitsPerCharacter]]></code>
+      <code><![CDATA[setHashFunction]]></code>
     </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA['foobar_bogus']]></code>
@@ -1053,11 +1040,11 @@
       <code><![CDATA['foobar_bogus']]></code>
       <code><![CDATA['foobar_bogus']]></code>
       <code><![CDATA['foobar_bogus']]></code>
-      <code>24</code>
-      <code>24</code>
+      <code><![CDATA[24]]></code>
+      <code><![CDATA[24]]></code>
     </InvalidArgument>
     <MissingReturnType>
-      <code>testCookieSameSiteIsMutable</code>
+      <code><![CDATA[testCookieSameSiteIsMutable]]></code>
     </MissingReturnType>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $this->config->getUseCookies()]]></code>
@@ -1065,52 +1052,52 @@
   </file>
   <file src="test/ConfigProviderTest.php">
     <MixedArgument>
-      <code>$abstractFactories</code>
+      <code><![CDATA[$abstractFactories]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$aliases[SessionManager::class]</code>
+      <code><![CDATA[$aliases[SessionManager::class]]]></code>
       <code><![CDATA[$config['abstract_factories']]]></code>
       <code><![CDATA[$config['aliases']]]></code>
       <code><![CDATA[$config['factories']]]></code>
-      <code>$config[LegacyConfigInterface::class]</code>
-      <code>$config[LegacyManagerInterface::class]</code>
-      <code>$config[LegacySessionManager::class]</code>
-      <code>$config[LegacyStorageInterface::class]</code>
-      <code>$factories[ConfigInterface::class]</code>
-      <code>$factories[ManagerInterface::class]</code>
-      <code>$factories[StorageInterface::class]</code>
+      <code><![CDATA[$config[LegacyConfigInterface::class]]]></code>
+      <code><![CDATA[$config[LegacyManagerInterface::class]]]></code>
+      <code><![CDATA[$config[LegacySessionManager::class]]]></code>
+      <code><![CDATA[$config[LegacyStorageInterface::class]]]></code>
+      <code><![CDATA[$factories[ConfigInterface::class]]]></code>
+      <code><![CDATA[$factories[ManagerInterface::class]]]></code>
+      <code><![CDATA[$factories[StorageInterface::class]]]></code>
       <code><![CDATA[$this->config['dependencies']['aliases']]]></code>
     </MixedArrayAccess>
     <MixedArrayOffset>
-      <code>$config[LegacyConfigInterface::class]</code>
-      <code>$config[LegacyManagerInterface::class]</code>
-      <code>$config[LegacySessionManager::class]</code>
-      <code>$config[LegacyStorageInterface::class]</code>
+      <code><![CDATA[$config[LegacyConfigInterface::class]]]></code>
+      <code><![CDATA[$config[LegacyManagerInterface::class]]]></code>
+      <code><![CDATA[$config[LegacySessionManager::class]]]></code>
+      <code><![CDATA[$config[LegacyStorageInterface::class]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code>$abstractFactories</code>
-      <code>$aliases</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$factories</code>
+      <code><![CDATA[$abstractFactories]]></code>
+      <code><![CDATA[$aliases]]></code>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$factories]]></code>
     </MixedAssignment>
     <MixedPropertyTypeCoercion>
-      <code>(new ConfigProvider())()</code>
+      <code><![CDATA[(new ConfigProvider())()]]></code>
     </MixedPropertyTypeCoercion>
     <UndefinedClass>
-      <code>LegacyConfigInterface</code>
-      <code>LegacyManagerInterface</code>
-      <code>LegacySessionManager</code>
-      <code>LegacyStorageInterface</code>
+      <code><![CDATA[LegacyConfigInterface]]></code>
+      <code><![CDATA[LegacyManagerInterface]]></code>
+      <code><![CDATA[LegacySessionManager]]></code>
+      <code><![CDATA[LegacyStorageInterface]]></code>
     </UndefinedClass>
   </file>
   <file src="test/ContainerTest.php">
     <MixedArgument>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
       <code><![CDATA[$metadata['EXPIRE_HOPS_KEYS']]]></code>
       <code><![CDATA[$metadata['EXPIRE_KEYS']]]></code>
     </MixedArgument>
@@ -1136,16 +1123,16 @@
       <code><![CDATA[$this->container['foo']['bar']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code>$hops</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
-      <code>$metadata</code>
+      <code><![CDATA[$hops]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
+      <code><![CDATA[$metadata]]></code>
     </MixedAssignment>
     <NoInterfaceProperties>
       <code><![CDATA[$this->manager->started]]></code>
@@ -1160,11 +1147,11 @@
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
     <RedundantConditionGivenDocblockType>
-      <code>assertIsArray</code>
+      <code><![CDATA[assertIsArray]]></code>
     </RedundantConditionGivenDocblockType>
     <UnusedVariable>
-      <code>$container</code>
-      <code>$container</code>
+      <code><![CDATA[$container]]></code>
+      <code><![CDATA[$container]]></code>
     </UnusedVariable>
   </file>
   <file src="test/SaveHandler/AbstractDbTableGatewayTest.php">
@@ -1173,124 +1160,120 @@
       <code><![CDATA[$this->adapter]]></code>
     </DocblockTypeContradiction>
     <MixedAssignment>
-      <code>$data</code>
+      <code><![CDATA[$data]]></code>
     </MixedAssignment>
     <PossiblyUndefinedMethod>
-      <code>count</code>
+      <code><![CDATA[count]]></code>
     </PossiblyUndefinedMethod>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[$this->adapter]]></code>
-      <code>assertTrue</code>
-      <code>is_string($data)</code>
+      <code><![CDATA[assertTrue]]></code>
+      <code><![CDATA[is_string($data)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/SaveHandler/CacheTest.php">
     <MixedAssignment>
-      <code>$data</code>
+      <code><![CDATA[$data]]></code>
     </MixedAssignment>
     <RedundantConditionGivenDocblockType>
-      <code>assertTrue</code>
-      <code>is_string($data)</code>
+      <code><![CDATA[assertTrue]]></code>
+      <code><![CDATA[is_string($data)]]></code>
     </RedundantConditionGivenDocblockType>
     <UndefinedDocblockClass>
-      <code>CacheAdapter</code>
+      <code><![CDATA[CacheAdapter]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="test/SaveHandler/DbTableGatewayOptionsTest.php">
     <UnusedVariable>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
+      <code><![CDATA[$options]]></code>
+      <code><![CDATA[$options]]></code>
+      <code><![CDATA[$options]]></code>
+      <code><![CDATA[$options]]></code>
+      <code><![CDATA[$options]]></code>
     </UnusedVariable>
   </file>
   <file src="test/SaveHandler/MongoDBTest.php">
     <DeprecatedMethod>
-      <code>count</code>
-      <code>count</code>
-      <code>count</code>
-      <code>count</code>
-      <code>count</code>
+      <code><![CDATA[count]]></code>
+      <code><![CDATA[count]]></code>
+      <code><![CDATA[count]]></code>
+      <code><![CDATA[count]]></code>
+      <code><![CDATA[count]]></code>
     </DeprecatedMethod>
     <InvalidArgument>
-      <code>123</code>
-      <code>123</code>
-      <code>123</code>
-      <code>456</code>
-      <code>456</code>
-      <code>456</code>
+      <code><![CDATA[123]]></code>
+      <code><![CDATA[123]]></code>
+      <code><![CDATA[123]]></code>
+      <code><![CDATA[456]]></code>
+      <code><![CDATA[456]]></code>
+      <code><![CDATA[456]]></code>
     </InvalidArgument>
-    <PossiblyFalseArgument>
-      <code><![CDATA[getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MONGODB_CONNECTION_STRING')]]></code>
-    </PossiblyFalseArgument>
     <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->mongoCollection]]></code>
-      <code>assertTrue</code>
-      <code>is_string($data)</code>
+      <code><![CDATA[assertTrue]]></code>
+      <code><![CDATA[is_string($data)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Service/ContainerAbstractServiceFactoryTest.php">
     <MixedAssignment>
-      <code>$container</code>
+      <code><![CDATA[$container]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>getManager</code>
+      <code><![CDATA[getManager]]></code>
     </MixedMethodCall>
   </file>
   <file src="test/Service/SessionConfigFactoryTest.php">
     <MissingReturnType>
-      <code>testServiceNotCreatedWhenInvalidSamesiteConfig</code>
+      <code><![CDATA[testServiceNotCreatedWhenInvalidSamesiteConfig]]></code>
     </MissingReturnType>
     <MixedAssignment>
-      <code>$config</code>
+      <code><![CDATA[$config]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>getName</code>
+      <code><![CDATA[getName]]></code>
     </MixedMethodCall>
   </file>
   <file src="test/Service/SessionManagerFactoryTest.php">
     <MixedArgument>
-      <code>$chain</code>
-      <code>$chain</code>
-      <code>$manager</code>
+      <code><![CDATA[$chain]]></code>
+      <code><![CDATA[$chain]]></code>
+      <code><![CDATA[$manager]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$listener[0]</code>
-      <code>$validatorData[Validator\HttpUserAgent::class]</code>
-      <code>$validatorData[Validator\RemoteAddr::class]</code>
+      <code><![CDATA[$listener[0]]]></code>
+      <code><![CDATA[$validatorData[Validator\HttpUserAgent::class]]]></code>
+      <code><![CDATA[$validatorData[Validator\RemoteAddr::class]]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code>$chain</code>
-      <code>$chain</code>
-      <code>$listener</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$manager</code>
-      <code>$validatorData</code>
+      <code><![CDATA[$chain]]></code>
+      <code><![CDATA[$chain]]></code>
+      <code><![CDATA[$listener]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$validatorData]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>getConfig</code>
-      <code>getSaveHandler</code>
-      <code>getStorage</code>
-      <code>getStorage</code>
-      <code>getValidatorChain</code>
-      <code>getValidatorChain</code>
-      <code>start</code>
-      <code>start</code>
-      <code>start</code>
+      <code><![CDATA[getConfig]]></code>
+      <code><![CDATA[getSaveHandler]]></code>
+      <code><![CDATA[getStorage]]></code>
+      <code><![CDATA[getStorage]]></code>
+      <code><![CDATA[getValidatorChain]]></code>
+      <code><![CDATA[getValidatorChain]]></code>
+      <code><![CDATA[start]]></code>
+      <code><![CDATA[start]]></code>
+      <code><![CDATA[start]]></code>
     </MixedMethodCall>
     <UnusedVariable>
-      <code>$manager</code>
-      <code>$manager</code>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$manager]]></code>
     </UnusedVariable>
   </file>
   <file src="test/Service/StorageFactoryTest.php">
@@ -1299,21 +1282,21 @@
       <code><![CDATA[$config['session_storage']['options']['input']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code>$storage</code>
-      <code>$storage</code>
-      <code>$test</code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$test]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>toArray</code>
+      <code><![CDATA[toArray]]></code>
     </MixedMethodCall>
     <UnusedVariable>
-      <code>$storage</code>
+      <code><![CDATA[$storage]]></code>
     </UnusedVariable>
   </file>
   <file src="test/SessionArrayStorageTest.php">
     <InvalidScalarArgument>
-      <code>$_SESSION</code>
-      <code>$_SESSION</code>
+      <code><![CDATA[$_SESSION]]></code>
+      <code><![CDATA[$_SESSION]]></code>
     </InvalidScalarArgument>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['test']['foo']]]></code>
@@ -1328,84 +1311,80 @@
       <code><![CDATA[$this->storage['baz']['foo']]]></code>
     </MixedArrayAssignment>
     <TypeDoesNotContainType>
-      <code>assertSame</code>
+      <code><![CDATA[assertSame]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="test/SessionManagerTest.php">
     <DocblockTypeContradiction>
-      <code>assertIsArray</code>
+      <code><![CDATA[assertIsArray]]></code>
     </DocblockTypeContradiction>
     <InvalidArgument>
       <code><![CDATA[$this->error]]></code>
-      <code>1</code>
       <code><![CDATA[[$this, 'handleErrors']]]></code>
     </InvalidArgument>
     <InvalidScalarArgument>
-      <code>$_SESSION</code>
+      <code><![CDATA[$_SESSION]]></code>
     </InvalidScalarArgument>
     <MixedArgument>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$value</code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$_SESSION[$key]</code>
-      <code>$_SESSION[$key]</code>
+      <code><![CDATA[$_SESSION[$key]]]></code>
+      <code><![CDATA[$_SESSION[$key]]]></code>
       <code><![CDATA[$_SESSION['__Laminas']['_VALID']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$header</code>
-      <code>$metaData</code>
-      <code>$value</code>
-      <code>$value</code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$metaData]]></code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedPropertyFetch>
       <code><![CDATA[$_SESSION->key1]]></code>
       <code><![CDATA[$_SESSION->key2]]></code>
     </MixedPropertyFetch>
     <NoValue>
-      <code>$_SESSION</code>
-      <code>$_SESSION</code>
+      <code><![CDATA[$_SESSION]]></code>
+      <code><![CDATA[$_SESSION]]></code>
     </NoValue>
-    <PossiblyNullOperand>
-      <code>var_export($headers, 1)</code>
-    </PossiblyNullOperand>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
     <PossiblyUndefinedVariable>
-      <code>$header</code>
-      <code>$header</code>
+      <code><![CDATA[$header]]></code>
+      <code><![CDATA[$header]]></code>
     </PossiblyUndefinedVariable>
     <RedundantCondition>
-      <code>assertFalse</code>
-      <code>assertSame</code>
+      <code><![CDATA[assertFalse]]></code>
+      <code><![CDATA[assertSame]]></code>
     </RedundantCondition>
     <TypeDoesNotContainType>
-      <code>assertIsArray</code>
+      <code><![CDATA[assertIsArray]]></code>
     </TypeDoesNotContainType>
     <UnusedVariable>
-      <code>$origId</code>
+      <code><![CDATA[$origId]]></code>
     </UnusedVariable>
   </file>
   <file src="test/SessionStorageTest.php">
     <InvalidMethodCall>
-      <code>getArrayCopy</code>
+      <code><![CDATA[getArrayCopy]]></code>
     </InvalidMethodCall>
     <InvalidScalarArgument>
-      <code>$_SESSION</code>
+      <code><![CDATA[$_SESSION]]></code>
     </InvalidScalarArgument>
   </file>
   <file src="test/StorageTest.php">
@@ -1422,92 +1401,92 @@
   </file>
   <file src="test/TestAsset/TestConfig.php">
     <ImplementedReturnTypeMismatch>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="test/TestAsset/TestContainer.php">
     <PropertyNotSetInConstructor>
-      <code>TestContainer</code>
+      <code><![CDATA[TestContainer]]></code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/TestDbTableGatewaySaveHandler.php">
     <MethodSignatureMustProvideReturnType>
-      <code>destroy</code>
-      <code>read</code>
+      <code><![CDATA[destroy]]></code>
+      <code><![CDATA[read]]></code>
     </MethodSignatureMustProvideReturnType>
     <PossiblyInvalidArgument>
-      <code>$id</code>
-      <code>$id</code>
+      <code><![CDATA[$id]]></code>
+      <code><![CDATA[$id]]></code>
     </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor>
-      <code>TestDbTableGatewaySaveHandler</code>
-      <code>TestDbTableGatewaySaveHandler</code>
-      <code>TestDbTableGatewaySaveHandler</code>
+      <code><![CDATA[TestDbTableGatewaySaveHandler]]></code>
+      <code><![CDATA[TestDbTableGatewaySaveHandler]]></code>
+      <code><![CDATA[TestDbTableGatewaySaveHandler]]></code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/TestManager.php">
     <ImplementedReturnTypeMismatch>
-      <code>void</code>
-      <code>void</code>
-      <code>void</code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidPropertyAssignmentValue>
-      <code>ArrayStorage::class</code>
+      <code><![CDATA[ArrayStorage::class]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnType>
-      <code>forgetMe</code>
-      <code>getId</code>
-      <code>getName</code>
-      <code>getValidatorChain</code>
-      <code>isValid</code>
-      <code>regenerateId</code>
-      <code>sessionExists</code>
-      <code>setValidatorChain</code>
+      <code><![CDATA[forgetMe]]></code>
+      <code><![CDATA[getId]]></code>
+      <code><![CDATA[getName]]></code>
+      <code><![CDATA[getValidatorChain]]></code>
+      <code><![CDATA[isValid]]></code>
+      <code><![CDATA[regenerateId]]></code>
+      <code><![CDATA[sessionExists]]></code>
+      <code><![CDATA[setValidatorChain]]></code>
     </InvalidReturnType>
     <PropertyNotSetInConstructor>
-      <code>TestManager</code>
+      <code><![CDATA[TestManager]]></code>
     </PropertyNotSetInConstructor>
     <UndefinedDocblockClass>
       <code><![CDATA[class-string<StorageInterface>]]></code>
-      <code>protected $storageDefaultClass = ArrayStorage::class;</code>
+      <code><![CDATA[protected $storageDefaultClass = ArrayStorage::class;]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="test/TestAsset/TestSaveHandler.php">
     <ImplementedParamTypeMismatch>
-      <code>$data</code>
+      <code><![CDATA[$data]]></code>
     </ImplementedParamTypeMismatch>
     <ImplementedReturnTypeMismatch>
-      <code>void</code>
-      <code>void</code>
+      <code><![CDATA[void]]></code>
+      <code><![CDATA[void]]></code>
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="test/TestAsset/TestSaveHandlerWithValidator.php">
     <ImplementedParamTypeMismatch>
-      <code>$data</code>
+      <code><![CDATA[$data]]></code>
     </ImplementedParamTypeMismatch>
     <ImplementedReturnTypeMismatch>
-      <code>bool</code>
+      <code><![CDATA[bool]]></code>
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="test/Validator/RemoteAddrTest.php">
     <MissingConstructor>
-      <code>$backup</code>
+      <code><![CDATA[$backup]]></code>
     </MissingConstructor>
   </file>
   <file src="test/Validator/ValidatorChainTest.php">
     <NoInterfaceProperties>
-      <code>$validator::$isValidCallCount</code>
+      <code><![CDATA[$validator::$isValidCallCount]]></code>
     </NoInterfaceProperties>
   </file>
 </files>

--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -448,17 +448,17 @@ abstract class AbstractContainer extends ArrayObject
     /**
      * Unset a single key in the container
      *
-     * @param  string $key
+     * @param  string $offset
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($offset)
     {
-        if (! $this->offsetExists($key)) {
+        if (! $this->offsetExists($offset)) {
             return;
         }
         $storage = $this->getStorage();
         $name    = $this->getName();
-        unset($storage[$name][$key]);
+        unset($storage[$name][$offset]);
     }
 
     /** @inheritDoc */

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -214,7 +214,7 @@ class SessionConfig extends StandardConfig
             'use_trans_sid',
             'cookie_httponly' => (bool) ini_get('session.' . $storageOption),
 
-            'save_handler' => $this->saveHandler ?: $this->sessionModuleName(),
+            'save_handler' => $this->saveHandler ?? $this->sessionModuleName(),
 
             default => ini_get('session.' . $storageOption),
         };

--- a/src/SaveHandler/MongoDBOptions.php
+++ b/src/SaveHandler/MongoDBOptions.php
@@ -81,7 +81,8 @@ class MongoDBOptions extends AbstractOptions
     {
         parent::__construct($options);
 
-        $mongoVersion = phpversion('mongo') ?: '0.0.0';
+        $mongoVersion = phpversion('mongo');
+        $mongoVersion = $mongoVersion === false ? '0.0.0' : $mongoVersion;
         if ($this->saveOptions === ['w' => 1] && version_compare($mongoVersion, '1.3.0', '<')) {
             $this->saveOptions = ['safe' => true];
         }

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -65,7 +65,7 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     public function canCreate(ContainerInterface $container, $requestedName)
     {
         $config = $this->getConfig($container);
-        if (empty($config)) {
+        if ($config === []) {
             return false;
         }
 
@@ -112,7 +112,7 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     /**
      * Retrieve config from service locator, and cache for later
      *
-     * @return false|array
+     * @return array
      */
     protected function getConfig(ContainerInterface $container)
     {

--- a/src/Validator/HttpUserAgent.php
+++ b/src/Validator/HttpUserAgent.php
@@ -19,7 +19,7 @@ class HttpUserAgent implements ValidatorInterface
      */
     public function __construct($data = null)
     {
-        if (empty($data)) {
+        if ($data === null || $data === '') {
             $data = $_SERVER['HTTP_USER_AGENT'] ?? null;
         }
         $this->data = $data;

--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -3,6 +3,7 @@
 namespace Laminas\Session\Validator;
 
 use function ini_get;
+use function is_numeric;
 use function preg_match;
 use function session_id;
 use function strrpos;
@@ -30,7 +31,7 @@ class Id implements ValidatorInterface
      */
     public function __construct($id = null)
     {
-        if (empty($id)) {
+        if ($id === null || $id === '') {
             $id = session_id();
         }
 
@@ -50,13 +51,14 @@ class Id implements ValidatorInterface
         $saveHandler = ini_get('session.save_handler');
         if ($saveHandler === 'cluster') { // Zend Server SC, validate only after last dash
             $dashPos = strrpos($id, '-');
-            if ($dashPos) {
+            if ($dashPos !== false) {
                 $id = substr($id, $dashPos + 1);
             }
         }
 
         // Get the session id bits per character INI setting, using 5 if unavailable
-        $hashBitsPerChar = ini_get('session.sid_bits_per_character') ?: 5;
+        $hashBitsPerChar = ini_get('session.sid_bits_per_character');
+        $hashBitsPerChar = is_numeric($hashBitsPerChar) ? (int) $hashBitsPerChar : 5;
 
         switch ($hashBitsPerChar) {
             case 4:

--- a/src/Validator/RemoteAddr.php
+++ b/src/Validator/RemoteAddr.php
@@ -48,7 +48,7 @@ class RemoteAddr implements SessionValidator
      */
     public function __construct($data = null)
     {
-        if (empty($data)) {
+        if ($data === null || $data === '') {
             $data = $this->getIpAddress();
         }
         $this->data = $data;

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -418,14 +418,14 @@ class SessionConfigTest extends TestCase
 
     public function testCookieSecureIsMutable(): void
     {
-        $value = ! ((bool) ini_get('session.cookie_secure'));
+        $value = ! (bool) ini_get('session.cookie_secure');
         $this->config->setCookieSecure($value);
         self::assertEquals($value, $this->config->getCookieSecure());
     }
 
     public function testCookieSecureAltersIniSetting(): void
     {
-        $value = ! ((bool) ini_get('session.cookie_secure'));
+        $value = ! (bool) ini_get('session.cookie_secure');
         $this->config->setCookieSecure($value);
         self::assertEquals($value, ini_get('session.cookie_secure'));
     }
@@ -439,14 +439,14 @@ class SessionConfigTest extends TestCase
 
     public function testCookieHttpOnlyIsMutable(): void
     {
-        $value = ! ((bool) ini_get('session.cookie_httponly'));
+        $value = ! (bool) ini_get('session.cookie_httponly');
         $this->config->setCookieHttpOnly($value);
         self::assertEquals($value, $this->config->getCookieHttpOnly());
     }
 
     public function testCookieHttpOnlyAltersIniSetting(): void
     {
-        $value = ! ((bool) ini_get('session.cookie_httponly'));
+        $value = ! (bool) ini_get('session.cookie_httponly');
         $this->config->setCookieHttpOnly($value);
         self::assertEquals($value, ini_get('session.cookie_httponly'));
     }
@@ -460,14 +460,14 @@ class SessionConfigTest extends TestCase
 
     public function testUseCookiesIsMutable(): void
     {
-        $value = ! ((bool) ini_get('session.use_cookies'));
+        $value = ! (bool) ini_get('session.use_cookies');
         $this->config->setUseCookies($value);
         self::assertEquals($value, $this->config->getUseCookies());
     }
 
     public function testUseCookiesAltersIniSetting(): void
     {
-        $value = ! ((bool) ini_get('session.use_cookies'));
+        $value = ! (bool) ini_get('session.use_cookies');
         $this->config->setUseCookies($value);
         self::assertEquals($value, (bool) ini_get('session.use_cookies'));
     }
@@ -481,14 +481,14 @@ class SessionConfigTest extends TestCase
 
     public function testUseOnlyCookiesIsMutable(): void
     {
-        $value = ! ((bool) ini_get('session.use_only_cookies'));
+        $value = ! (bool) ini_get('session.use_only_cookies');
         $this->config->setOption('use_only_cookies', $value);
         self::assertEquals($value, (bool) $this->config->getOption('use_only_cookies'));
     }
 
     public function testUseOnlyCookiesAltersIniSetting(): void
     {
-        $value = ! ((bool) ini_get('session.use_only_cookies'));
+        $value = ! (bool) ini_get('session.use_only_cookies');
         $this->config->setOption('use_only_cookies', $value);
         self::assertEquals($value, (bool) ini_get('session.use_only_cookies'));
     }
@@ -517,7 +517,6 @@ class SessionConfigTest extends TestCase
         $this->config->setOption('referer_check', 'BARBAZ');
         self::assertEquals('BARBAZ', ini_get('session.referer_check'));
     }
-
 
     // session.cache_limiter
 
@@ -605,14 +604,14 @@ class SessionConfigTest extends TestCase
 
     public function testUseTransSidIsMutable(): void
     {
-        $value = ! ((bool) ini_get('session.use_trans_sid'));
+        $value = ! (bool) ini_get('session.use_trans_sid');
         $this->config->setOption('use_trans_sid', $value);
         self::assertEquals($value, (bool) $this->config->getOption('use_trans_sid'));
     }
 
     public function testUseTransSidAltersIniSetting(): void
     {
-        $value = ! ((bool) ini_get('session.use_trans_sid'));
+        $value = ! (bool) ini_get('session.use_trans_sid');
         $this->config->setOption('use_trans_sid', $value);
         self::assertEquals($value, (bool) ini_get('session.use_trans_sid'));
     }

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -11,9 +11,7 @@ use ReflectionProperty;
 use SessionHandlerInterface;
 use stdClass;
 
-use function array_merge;
 use function extension_loaded;
-use function hash_algos;
 use function ini_get;
 use function session_start;
 use function var_export;
@@ -420,14 +418,14 @@ class SessionConfigTest extends TestCase
 
     public function testCookieSecureIsMutable(): void
     {
-        $value = ! ini_get('session.cookie_secure');
+        $value = ! ((bool) ini_get('session.cookie_secure'));
         $this->config->setCookieSecure($value);
         self::assertEquals($value, $this->config->getCookieSecure());
     }
 
     public function testCookieSecureAltersIniSetting(): void
     {
-        $value = ! ini_get('session.cookie_secure');
+        $value = ! ((bool) ini_get('session.cookie_secure'));
         $this->config->setCookieSecure($value);
         self::assertEquals($value, ini_get('session.cookie_secure'));
     }
@@ -441,14 +439,14 @@ class SessionConfigTest extends TestCase
 
     public function testCookieHttpOnlyIsMutable(): void
     {
-        $value = ! ini_get('session.cookie_httponly');
+        $value = ! ((bool) ini_get('session.cookie_httponly'));
         $this->config->setCookieHttpOnly($value);
         self::assertEquals($value, $this->config->getCookieHttpOnly());
     }
 
     public function testCookieHttpOnlyAltersIniSetting(): void
     {
-        $value = ! ini_get('session.cookie_httponly');
+        $value = ! ((bool) ini_get('session.cookie_httponly'));
         $this->config->setCookieHttpOnly($value);
         self::assertEquals($value, ini_get('session.cookie_httponly'));
     }
@@ -462,14 +460,14 @@ class SessionConfigTest extends TestCase
 
     public function testUseCookiesIsMutable(): void
     {
-        $value = ! ini_get('session.use_cookies');
+        $value = ! ((bool) ini_get('session.use_cookies'));
         $this->config->setUseCookies($value);
         self::assertEquals($value, $this->config->getUseCookies());
     }
 
     public function testUseCookiesAltersIniSetting(): void
     {
-        $value = ! ini_get('session.use_cookies');
+        $value = ! ((bool) ini_get('session.use_cookies'));
         $this->config->setUseCookies($value);
         self::assertEquals($value, (bool) ini_get('session.use_cookies'));
     }
@@ -483,14 +481,14 @@ class SessionConfigTest extends TestCase
 
     public function testUseOnlyCookiesIsMutable(): void
     {
-        $value = ! ini_get('session.use_only_cookies');
+        $value = ! ((bool) ini_get('session.use_only_cookies'));
         $this->config->setOption('use_only_cookies', $value);
         self::assertEquals($value, (bool) $this->config->getOption('use_only_cookies'));
     }
 
     public function testUseOnlyCookiesAltersIniSetting(): void
     {
-        $value = ! ini_get('session.use_only_cookies');
+        $value = ! ((bool) ini_get('session.use_only_cookies'));
         $this->config->setOption('use_only_cookies', $value);
         self::assertEquals($value, (bool) ini_get('session.use_only_cookies'));
     }
@@ -520,35 +518,6 @@ class SessionConfigTest extends TestCase
         self::assertEquals('BARBAZ', ini_get('session.referer_check'));
     }
 
-    public function testSetEntropyFileError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->getEntropyFile();
-    }
-
-    public function testGetEntropyFileError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->setEntropyFile(__FILE__);
-    }
-
-    // session.entropy_length
-
-    public function testGetEntropyLengthError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->getEntropyLength();
-    }
-
-    public function testSetEntropyLengthError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->setEntropyLength(0);
-    }
 
     // session.cache_limiter
 
@@ -636,67 +605,16 @@ class SessionConfigTest extends TestCase
 
     public function testUseTransSidIsMutable(): void
     {
-        $value = ! ini_get('session.use_trans_sid');
+        $value = ! ((bool) ini_get('session.use_trans_sid'));
         $this->config->setOption('use_trans_sid', $value);
         self::assertEquals($value, (bool) $this->config->getOption('use_trans_sid'));
     }
 
     public function testUseTransSidAltersIniSetting(): void
     {
-        $value = ! ini_get('session.use_trans_sid');
+        $value = ! ((bool) ini_get('session.use_trans_sid'));
         $this->config->setOption('use_trans_sid', $value);
         self::assertEquals($value, (bool) ini_get('session.use_trans_sid'));
-    }
-
-    // session.hash_function
-
-    public function hashFunctions(): array
-    {
-        $hashFunctions = array_merge([0, 1], hash_algos());
-        $provider      = [];
-        foreach ($hashFunctions as $function) {
-            $provider[] = [$function];
-        }
-        return $provider;
-    }
-
-    public function testGetHashFunctionError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->getHashFunction();
-    }
-
-    public function testSetHashFunctionError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->setHashFunction('foobar_bogus');
-    }
-
-    // session.hash_bits_per_character
-
-    public function hashBitsPerCharacters(): array
-    {
-        return [
-            [4],
-            [5],
-            [6],
-        ];
-    }
-
-    public function testGetHashBitsPerCharacterError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->getHashBitsPerCharacter();
-    }
-
-    public function testSetHashBitsPerCharacterError(): void
-    {
-        $this->markTestSkipped('This functionality is deprecated as of PHP 7.1 and should not be used anyways');
-        $this->expectDeprecation();
-        $this->config->setHashBitsPerCharacter(5);
     }
 
     // session.sid_length

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -259,6 +259,7 @@ class ContainerTest extends TestCase
 
     public function testGetKeyWithContainerExpirationInPastResetsToNull(): void
     {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
         $this->container->foo = 'bar';
         $storage              = $this->manager->getStorage();
         $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
@@ -267,6 +268,7 @@ class ContainerTest extends TestCase
 
     public function testGetKeyWithExpirationInPastResetsToNull(): void
     {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
         $this->container->foo = 'bar';
         $this->container->bar = 'baz';
         $storage              = $this->manager->getStorage();
@@ -277,6 +279,7 @@ class ContainerTest extends TestCase
 
     public function testKeyExistsWithContainerExpirationInPastReturnsFalse(): void
     {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
         $this->container->foo = 'bar';
         $storage              = $this->manager->getStorage();
         $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
@@ -285,6 +288,7 @@ class ContainerTest extends TestCase
 
     public function testKeyExistsWithExpirationInPastReturnsFalse(): void
     {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
         $this->container->foo = 'bar';
         $this->container->bar = 'baz';
         $storage              = $this->manager->getStorage();
@@ -295,6 +299,7 @@ class ContainerTest extends TestCase
 
     public function testKeyExistsWithContainerExpirationInPastWithSetExpirationSecondsReturnsFalse(): void
     {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
         $this->container->foo = 'bar';
         $storage              = $this->manager->getStorage();
         $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
@@ -304,6 +309,7 @@ class ContainerTest extends TestCase
 
     public function testSettingExpiredKeyOverwritesExpiryMetadataForThatKey(): void
     {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
         $this->container->foo = 'bar';
         $storage              = $this->manager->getStorage();
         $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
@@ -494,6 +500,7 @@ class ContainerTest extends TestCase
 
     public function testIterationHonorsExpirationTimestamps(): void
     {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
         $this->container->foo = 'bar';
         $this->container->bar = 'baz';
         $storage              = $this->manager->getStorage();

--- a/test/SaveHandler/DbTableGateway/MysqliAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/MysqliAdapterTest.php
@@ -14,12 +14,10 @@ use function sprintf;
 
 class MysqliAdapterTest extends AbstractDbTableGatewayTest
 {
-    /**
-     * @return Adapter
-     */
-    protected function getAdapter()
+    protected function getAdapter(): Adapter
     {
-        if (! getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL')) {
+        $enabled = (bool) getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL');
+        if (! $enabled) {
             self::markTestSkipped(
                 sprintf(
                     '%s tests with MySQL are disabled',

--- a/test/SaveHandler/DbTableGateway/PdoMysqlAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/PdoMysqlAdapterTest.php
@@ -19,7 +19,8 @@ class PdoMysqlAdapterTest extends AbstractDbTableGatewayTest
      */
     protected function getAdapter()
     {
-        if (! getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL')) {
+        $enabled = (bool) getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MYSQL');
+        if (! $enabled) {
             self::markTestSkipped(
                 sprintf(
                     '%s tests with MySQL are disabled',
@@ -28,7 +29,7 @@ class PdoMysqlAdapterTest extends AbstractDbTableGatewayTest
             );
         }
 
-        if (! extension_loaded('mysqli')) {
+        if (! extension_loaded('pdo_mysql')) {
             self::markTestSkipped(
                 sprintf(
                     '%s tests with PDO_Mysql adapter are not enabled due to missing PDO_Mysql extension',

--- a/test/SaveHandler/DbTableGateway/PdoSqliteAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/PdoSqliteAdapterTest.php
@@ -13,10 +13,7 @@ use function sprintf;
 
 class PdoSqliteAdapterTest extends AbstractDbTableGatewayTest
 {
-    /**
-     * @return Adapter
-     */
-    protected function getAdapter()
+    protected function getAdapter(): Adapter
     {
         if (! extension_loaded('pdo_sqlite')) {
             self::markTestSkipped(

--- a/test/SaveHandler/DbTableGateway/PgsqlAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/PgsqlAdapterTest.php
@@ -14,12 +14,10 @@ use function sprintf;
 
 class PgsqlAdapterTest extends AbstractDbTableGatewayTest
 {
-    /**
-     * @return Adapter
-     */
-    protected function getAdapter()
+    protected function getAdapter(): Adapter
     {
-        if (! getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_PGSQL')) {
+        $enabled = (bool) getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_PGSQL');
+        if (! $enabled) {
             self::markTestSkipped(
                 sprintf(
                     '%s tests with Pgsql adapter are disabled',
@@ -28,7 +26,7 @@ class PgsqlAdapterTest extends AbstractDbTableGatewayTest
             );
         }
 
-        if (! extension_loaded('mysqli')) {
+        if (! extension_loaded('pdo_pgsql')) {
             self::markTestSkipped(
                 sprintf(
                     '%s tests with Pgsql adapter are not enabled due to missing Pgsql extension',

--- a/test/SaveHandler/MongoDBOptionsTest.php
+++ b/test/SaveHandler/MongoDBOptionsTest.php
@@ -19,14 +19,16 @@ class MongoDBOptionsTest extends TestCase
 {
     public function testDefaults(): void
     {
-        if (! getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MONGODB')) {
+        $enabled = (bool) getenv('TESTS_LAMINAS_SESSION_ADAPTER_DRIVER_MONGODB');
+        if (! $enabled) {
             $this->markTestSkipped('MongoDB tests are disabled');
         }
 
         $options = new MongoDBOptions();
         self::assertNull($options->getDatabase());
         self::assertNull($options->getCollection());
-        $mongoVersion       = phpversion('mongo') ?: '0.0.0';
+        $mongoVersion       = phpversion('mongo');
+        $mongoVersion       = $mongoVersion === false ? '0.0.0' : $mongoVersion;
         $defaultSaveOptions = version_compare($mongoVersion, '1.3.0', '<') ? ['safe' => true] : ['w' => 1];
         self::assertEquals($defaultSaveOptions, $options->getSaveOptions());
         self::assertEquals('name', $options->getNameField());

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -413,7 +413,10 @@ class SessionManagerTest extends TestCase
         $sName   = $this->manager->getName();
 
         foreach ($headers as $header) {
-            if (stristr($header, 'Set-Cookie:') && stristr($header, $sName)) {
+            if (
+                stristr($header, 'Set-Cookie:') !== false
+                && stristr($header, $sName) !== false
+            ) {
                 $found = true;
             }
         }
@@ -443,7 +446,10 @@ class SessionManagerTest extends TestCase
         $sName   = $this->manager->getName();
 
         foreach ($headers as $header) {
-            if (stristr($header, 'Set-Cookie:') && stristr($header, $sName)) {
+            if (
+                stristr($header, 'Set-Cookie:') !== false
+                && stristr($header, $sName) !== false
+            ) {
                 $found = true;
             }
         }
@@ -600,7 +606,10 @@ class SessionManagerTest extends TestCase
         $sName   = $this->manager->getName();
 
         foreach ($headers as $header) {
-            if (stristr($header, 'Set-Cookie:') && stristr($header, $sName)) {
+            if (
+                stristr($header, 'Set-Cookie:') !== false
+                && stristr($header, $sName) !== false
+            ) {
                 $found = true;
             }
         }
@@ -629,7 +638,11 @@ class SessionManagerTest extends TestCase
         $cookie  = false;
 
         foreach ($headers as $header) {
-            if (stristr($header, 'Set-Cookie:') && stristr($header, $sName) && ! stristr($header, '=deleted')) {
+            if (
+                stristr($header, 'Set-Cookie:') !== false
+                && stristr($header, $sName) !== false
+                && stristr($header, '=deleted') === false
+            ) {
                 $found  = true;
                 $cookie = $header;
             }
@@ -673,7 +686,11 @@ class SessionManagerTest extends TestCase
         $cookie  = false;
 
         foreach ($headers as $header) {
-            if (stristr($header, 'Set-Cookie:') && stristr($header, $sName) && ! stristr($header, '=deleted')) {
+            if (
+                stristr($header, 'Set-Cookie:') !== false
+                && stristr($header, $sName) !== false
+                && stristr($header, '=deleted') === false
+            ) {
                 $found  = true;
                 $cookie = $header;
             }
@@ -687,9 +704,15 @@ class SessionManagerTest extends TestCase
             self::fail('Cookie did not contain expiry? ' . var_export($headers, true));
         }
 
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+
         $compare  = $_SERVER['REQUEST_TIME'] + $ttl;
         $cookieTs = $ts->getTimestamp();
-        self::assertContains($cookieTs, range($compare, $compare + 10), 'Session cookie: ' . var_export($headers, true));
+        self::assertContains(
+            $cookieTs,
+            range($compare, $compare + 10),
+            'Session cookie: ' . var_export($headers, true),
+        );
     }
 
     /**
@@ -712,7 +735,11 @@ class SessionManagerTest extends TestCase
         $sName   = $this->manager->getName();
 
         foreach ($headers as $header) {
-            if (stristr($header, 'Set-Cookie:') && stristr($header, $sName) && ! stristr($header, '=deleted')) {
+            if (
+                stristr($header, 'Set-Cookie:') !== false
+                && stristr($header, $sName) !== false
+                && stristr($header, '=deleted') === false
+            ) {
                 $found = true;
             }
         }

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -689,7 +689,7 @@ class SessionManagerTest extends TestCase
 
         $compare  = $_SERVER['REQUEST_TIME'] + $ttl;
         $cookieTs = $ts->getTimestamp();
-        self::assertContains($cookieTs, range($compare, $compare + 10), 'Session cookie: ' . var_export($headers, 1));
+        self::assertContains($cookieTs, range($compare, $compare + 10), 'Session cookie: ' . var_export($headers, true));
     }
 
     /**


### PR DESCRIPTION
- Enables Mongo, MySQL and PgSQL tests
- Upgrades Psalm
- Closes #78 
- Add BC Check to the matrix
- Stop ignoring platform reqs

The BC break reported by tooling is actually a problem with Laminas\Stdlib. ArrayObject::offsetGet() has the wrong parameter name.