### PR TITLE
Declare timeout option nullable

### DIFF
--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -22,7 +22,7 @@ use function strtr;
  *     name?: non-empty-string,
  *     salt?: non-empty-string,
  *     session?: Container,
- *     timeout?: int,
+ *     timeout?: ?int,
  * }
  */
 final class Csrf extends AbstractValidator


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fix Psalm complaint when 'timeout' option is disabled (set to NULL - default is 300) via constructor.
