### PR TITLE
Revert removal of checks for the `SID` constant deprecated in PHP 8.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1592,16 +1592,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.64.1",
+            "version": "2.64.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "9db115056b666b7540c951b6d4477b8e0b52b9ad"
+                "reference": "771e504760448ac7af660710237ceb93be602e08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/9db115056b666b7540c951b6d4477b8e0b52b9ad",
-                "reference": "9db115056b666b7540c951b6d4477b8e0b52b9ad",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
+                "reference": "771e504760448ac7af660710237ceb93be602e08",
                 "shasum": ""
             },
             "require": {
@@ -1672,7 +1672,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-08-01T09:32:54+00:00"
+            "time": "2024-11-26T21:29:17+00:00"
         },
         {
             "name": "mongodb/mongodb",
@@ -4216,16 +4216,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
                 "shasum": ""
             },
             "require": {
@@ -4263,7 +4263,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -4279,7 +4279,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -4823,16 +4823,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
-                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
                 "shasum": ""
             },
             "require": {
@@ -4886,7 +4886,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -4902,7 +4902,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/string",
@@ -5115,11 +5115,11 @@
             "type": "project",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev",
-                    "dev-4.x": "4.x-dev",
-                    "dev-3.x": "3.x-dev",
+                    "dev-1.x": "1.x-dev",
                     "dev-2.x": "2.x-dev",
-                    "dev-1.x": "1.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -8,33 +8,33 @@
     "packages": [
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.13.1",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "933d1b5cf03fa4cf3016cebfd0555fa2ba3f2024"
+                "reference": "1837cafaaaee74437f6d8ec9ff7da03e6f81d809"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/933d1b5cf03fa4cf3016cebfd0555fa2ba3f2024",
-                "reference": "933d1b5cf03fa4cf3016cebfd0555fa2ba3f2024",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1837cafaaaee74437f6d8ec9ff7da03e6f81d809",
+                "reference": "1837cafaaaee74437f6d8ec9ff7da03e6f81d809",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-stdlib": "^3.18",
-                "phpbench/phpbench": "^1.2.15",
-                "phpunit/phpunit": "^10.5.5",
-                "psalm/plugin-phpunit": "^0.18.4",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "laminas/laminas-stdlib": "^3.20",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
                 "psr/container": "^1.1.2 || ^2.0.2",
-                "vimeo/psalm": "^5.18"
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
@@ -72,7 +72,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-06-24T14:01:06+00:00"
+            "time": "2024-11-21T11:31:22+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -1529,6 +1529,7 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2024-10-16T09:06:57+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -849,29 +849,27 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/31610dbb31faa98e6b5447b62340826f54fbc4e9",
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
+                "doctrine/coding-standard": "^9 || ^12",
+                "phpstan/phpstan": "1.4.10 || 2.0.3",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -879,7 +877,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -890,9 +888,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
             },
-            "time": "2024-01-30T19:34:25+00:00"
+            "time": "2024-12-07T21:18:45+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1191,8 +1189,8 @@
             "type": "library",
             "extra": {
                 "laminas": {
-                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Memory\\ConfigProvider",
-                    "module": "Laminas\\Cache\\Storage\\Adapter\\Memory"
+                    "module": "Laminas\\Cache\\Storage\\Adapter\\Memory",
+                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Memory\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -1412,23 +1410,23 @@
         },
         {
             "name": "laminas/laminas-http",
-            "version": "2.20.0",
+            "version": "2.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-http.git",
-                "reference": "a66bfb65c698aad6ee9f10df42cb5902f2c3dec8"
+                "reference": "a9867e4d1cda3dbad208903239c83a3d670cce10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/a66bfb65c698aad6ee9f10df42cb5902f2c3dec8",
-                "reference": "a66bfb65c698aad6ee9f10df42cb5902f2c3dec8",
+                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/a9867e4d1cda3dbad208903239c83a3d670cce10",
+                "reference": "a9867e4d1cda3dbad208903239c83a3d670cce10",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-loader": "^2.10",
                 "laminas/laminas-stdlib": "^3.6",
                 "laminas/laminas-uri": "^2.11",
-                "laminas/laminas-validator": "^2.15",
+                "laminas/laminas-validator": "^2.15 || ^3.0",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
@@ -1473,20 +1471,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-18T07:35:59+00:00"
+            "time": "2024-12-04T09:17:39+00:00"
         },
         {
             "name": "laminas/laminas-loader",
-            "version": "2.11.0",
+            "version": "2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "f2eedd3a6e774d965158fd11946bb1eba72e298c"
+                "reference": "c507d5eccb969f7208434e3980680a1f6c0b1d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/f2eedd3a6e774d965158fd11946bb1eba72e298c",
-                "reference": "f2eedd3a6e774d965158fd11946bb1eba72e298c",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/c507d5eccb969f7208434e3980680a1f6c0b1d8d",
+                "reference": "c507d5eccb969f7208434e3980680a1f6c0b1d8d",
                 "shasum": ""
             },
             "require": {
@@ -1530,25 +1528,25 @@
                 }
             ],
             "abandoned": true,
-            "time": "2024-10-16T09:06:57+00:00"
+            "time": "2024-12-05T14:43:32+00:00"
         },
         {
             "name": "laminas/laminas-uri",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-uri.git",
-                "reference": "95a41a7592bacf4c648648a88b7c94b0c5c22b9e"
+                "reference": "de53600ae8153b3605bb6edce8aeeef524eaafba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/95a41a7592bacf4c648648a88b7c94b0c5c22b9e",
-                "reference": "95a41a7592bacf4c648648a88b7c94b0c5c22b9e",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/de53600ae8153b3605bb6edce8aeeef524eaafba",
+                "reference": "de53600ae8153b3605bb6edce8aeeef524eaafba",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-escaper": "^2.9",
-                "laminas/laminas-validator": "^2.39",
+                "laminas/laminas-validator": "^2.39 || ^3.0",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
@@ -1588,7 +1586,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-08-03T21:22:51+00:00"
+            "time": "2024-12-03T12:27:51+00:00"
         },
         {
             "name": "laminas/laminas-validator",
@@ -2091,16 +2089,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.0",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "f3558a4c23426d12bffeaab463f8a8d8b681193c"
+                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/f3558a4c23426d12bffeaab463f8a8d8b681193c",
-                "reference": "f3558a4c23426d12bffeaab463f8a8d8b681193c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
                 "shasum": ""
             },
             "require": {
@@ -2149,9 +2147,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.0"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.1"
             },
-            "time": "2024-11-12T11:25:25+00:00"
+            "time": "2024-12-07T09:39:29+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -93,6 +93,9 @@ class SessionManager extends AbstractManager
             return true;
         }
 
+        /**
+         * @var string|false $sid
+         */
         $sid = defined('SID') ? constant('SID') : false;
 
         if ($sid !== false && $this->getId()) {

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -9,6 +9,8 @@ use Traversable;
 
 use function array_key_exists;
 use function array_merge;
+use function constant;
+use function defined;
 use function headers_sent;
 use function is_array;
 use function iterator_to_array;
@@ -88,6 +90,12 @@ class SessionManager extends AbstractManager
     public function sessionExists()
     {
         if (session_status() === PHP_SESSION_ACTIVE) {
+            return true;
+        }
+
+        $sid = defined('SID') ? constant('SID') : false;
+
+        if ($sid !== false && $this->getId()) {
             return true;
         }
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -91,12 +91,10 @@ class SessionManager extends AbstractManager
             return true;
         }
 
-        if ($this->getId()) {
-            return true;
-        }
         if (headers_sent()) {
             return true;
         }
+
         return false;
     }
 

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -17,6 +17,7 @@ use Laminas\Session\Storage\SessionStorage;
 use Laminas\Session\Validator\Id;
 use Laminas\Session\Validator\RemoteAddr;
 use LaminasTest\Session\TestAsset\Php81CompatibleStorageInterface;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Traversable;
 
@@ -35,6 +36,7 @@ use function session_start;
 use function session_write_close;
 use function set_error_handler;
 use function stristr;
+use function uniqid;
 use function var_export;
 use function xdebug_get_headers;
 
@@ -900,6 +902,29 @@ class SessionManagerTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Session validation failed');
         $this->manager->start();
+    }
+
+    #[RunInSeparateProcess]
+    public function testSettingTheIdentifierBeforeStartingTheSessionYieldsTheExpectedId(): void
+    {
+        $manager = new SessionManager();
+
+        $id = uniqid();
+
+        $manager->setId($id);
+
+        // setting a session id does not mark a session as started
+        self::assertFalse($manager->sessionExists());
+
+        $manager->start();
+
+        self::assertTrue($manager->sessionExists());
+
+        $manager->writeClose();
+
+        // calling writeClose() does not mark the session as closed
+        self::assertTrue($manager->sessionExists());
+        self::assertSame($id, $manager->getId());
     }
 
     /** @param non-empty-string $property */

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -160,8 +160,6 @@ class SessionManagerTest extends TestCase
         $this->assertAttributeEquals([], 'validators', $manager);
     }
 
-    // Session-related functionality
-
     #[RunInSeparateProcess]
     public function testSessionExistsReturnsFalseWhenNoSessionStarted(): void
     {

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -17,6 +17,7 @@ use Laminas\Session\Storage\SessionStorage;
 use Laminas\Session\Validator\Id;
 use Laminas\Session\Validator\RemoteAddr;
 use LaminasTest\Session\TestAsset\Php81CompatibleStorageInterface;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Traversable;
@@ -161,18 +162,14 @@ class SessionManagerTest extends TestCase
 
     // Session-related functionality
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSessionExistsReturnsFalseWhenNoSessionStarted(): void
     {
         $this->manager = new SessionManager();
         self::assertFalse($this->manager->sessionExists());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSessionExistsReturnsTrueWhenSessionStarted(): void
     {
         $this->manager = new SessionManager();
@@ -180,9 +177,8 @@ class SessionManagerTest extends TestCase
         self::assertTrue($this->manager->sessionExists());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
     public function testSessionExistsReturnsTrueWhenSessionStartedThenWritten(): void
     {
         $this->manager = new SessionManager();
@@ -191,9 +187,8 @@ class SessionManagerTest extends TestCase
         self::assertTrue($this->manager->sessionExists());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
     public function testSessionExistsReturnsFalseWhenSessionStartedThenDestroyed(): void
     {
         $this->manager = new SessionManager();
@@ -202,9 +197,7 @@ class SessionManagerTest extends TestCase
         self::assertFalse($this->manager->sessionExists());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSessionIsStartedAfterCallingStart(): void
     {
         $this->manager = new SessionManager();
@@ -213,9 +206,8 @@ class SessionManagerTest extends TestCase
         self::assertTrue($this->manager->sessionExists());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
     public function testStartDoesNothingWhenCalledAfterWriteCloseOperation(): void
     {
         $this->manager = new SessionManager();
@@ -228,9 +220,7 @@ class SessionManagerTest extends TestCase
         self::assertEquals($id1, $id2);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testStartWithOldTraversableSessionData(): void
     {
         // pre-populate session with data
@@ -247,9 +237,7 @@ class SessionManagerTest extends TestCase
         self::assertEquals('value2', $_SESSION->key2);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testStorageContentIsPreservedByWriteCloseOperation(): void
     {
         $this->manager = new SessionManager();
@@ -261,9 +249,8 @@ class SessionManagerTest extends TestCase
         self::assertEquals('bar', $storage['foo']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
     public function testStartCreatesNewSessionIfPreviousSessionHasBeenDestroyed(): void
     {
         $this->manager = new SessionManager();
@@ -276,9 +263,7 @@ class SessionManagerTest extends TestCase
         self::assertNotEquals($id1, $id2);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testStartConvertsSessionDataFromStorageInterfaceToArrayBeforeMerging(): void
     {
         $this->manager = new SessionManager();
@@ -300,9 +285,7 @@ class SessionManagerTest extends TestCase
         self::assertSame($data[$key], $_SESSION[$key]);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testStartConvertsSessionDataFromTraversableToArrayBeforeMerging(): void
     {
         $this->manager = new SessionManager();
@@ -336,9 +319,7 @@ class SessionManagerTest extends TestCase
         self::assertContains('already sent', $this->error);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testGetNameReturnsSessionName(): void
     {
         $this->manager = new SessionManager();
@@ -346,9 +327,7 @@ class SessionManagerTest extends TestCase
         self::assertEquals($ini, $this->manager->getName());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSetNameRaisesExceptionOnInvalidName(): void
     {
         $this->manager = new SessionManager();
@@ -357,9 +336,7 @@ class SessionManagerTest extends TestCase
         $this->manager->setName('foo bar!');
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSetNameSetsSessionNameOnSuccess(): void
     {
         $this->manager = new SessionManager();
@@ -368,9 +345,8 @@ class SessionManagerTest extends TestCase
         self::assertEquals('foobar', session_name());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
     public function testCanSetNewSessionNameAfterSessionDestroyed(): void
     {
         $this->manager = new SessionManager();
@@ -381,9 +357,7 @@ class SessionManagerTest extends TestCase
         self::assertEquals('foobar', session_name());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSettingNameWhenAnActiveSessionExistsRaisesException(): void
     {
         $this->manager = new SessionManager();
@@ -393,9 +367,7 @@ class SessionManagerTest extends TestCase
         $this->manager->setName('foobar');
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testDestroyByDefaultSendsAnExpireCookie(): void
     {
         if (! extension_loaded('xdebug')) {
@@ -426,9 +398,7 @@ class SessionManagerTest extends TestCase
         self::assertTrue($found, 'No session cookie found: ' . var_export($headers, true));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSendingFalseToSendExpireCookieWhenCallingDestroyShouldNotSendCookie(): void
     {
         if (! extension_loaded('xdebug')) {
@@ -463,9 +433,7 @@ class SessionManagerTest extends TestCase
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testDestroyDoesNotClearSessionStorageByDefault(): void
     {
         $this->manager = new SessionManager();
@@ -477,9 +445,7 @@ class SessionManagerTest extends TestCase
         self::assertEquals('bar', $storage['foo']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testPassingClearStorageOptionWhenCallingDestroyClearsStorage(): void
     {
         $this->manager = new SessionManager();
@@ -490,9 +456,7 @@ class SessionManagerTest extends TestCase
         self::assertFalse(isset($storage['foo']));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testDestroySessionWhenHeadersHaveBeenSent(): void
     {
         $this->manager = new SessionManager();
@@ -505,9 +469,7 @@ class SessionManagerTest extends TestCase
         self::assertFalse(isset($storage['foo']));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testCallingWriteCloseMarksStorageAsImmutable(): void
     {
         $this->manager = new SessionManager();
@@ -518,9 +480,8 @@ class SessionManagerTest extends TestCase
         self::assertTrue($storage->isImmutable());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
     public function testCallingWriteCloseShouldNotAlterSessionExistsStatus(): void
     {
         $this->manager = new SessionManager();
@@ -529,18 +490,14 @@ class SessionManagerTest extends TestCase
         self::assertTrue($this->manager->sessionExists());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testIdShouldBeEmptyPriorToCallingStart(): void
     {
         $this->manager = new SessionManager();
         self::assertSame('', $this->manager->getId());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testIdShouldBeMutablePriorToCallingStart(): void
     {
         $this->manager = new SessionManager();
@@ -549,9 +506,7 @@ class SessionManagerTest extends TestCase
         self::assertSame(self::class, session_id());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testIdShouldNotBeMutableAfterSessionStarted(): void
     {
         $this->manager = new SessionManager();
@@ -563,9 +518,7 @@ class SessionManagerTest extends TestCase
         $this->manager->setId(__METHOD__);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRegenerateIdShouldWorkAfterSessionStarted(): void
     {
         $this->manager = new SessionManager();
@@ -575,9 +528,7 @@ class SessionManagerTest extends TestCase
         self::assertNotSame($origId, $this->manager->getId());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRegenerateIdDoesNothingWhenSessioIsNotStarted(): void
     {
         $this->manager = new SessionManager();
@@ -587,9 +538,7 @@ class SessionManagerTest extends TestCase
         self::assertEquals('', $this->manager->getId());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRegeneratingIdAfterSessionStartedShouldSendExpireCookie(): void
     {
         if (! extension_loaded('xdebug')) {
@@ -619,9 +568,7 @@ class SessionManagerTest extends TestCase
         self::assertTrue($found, 'No session cookie found: ' . var_export($headers, true));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRememberMeShouldSendNewSessionCookieWithUpdatedTimestamp(): void
     {
         if (! extension_loaded('xdebug')) {
@@ -665,9 +612,7 @@ class SessionManagerTest extends TestCase
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRememberMeShouldSetTimestampBasedOnConfigurationByDefault(): void
     {
         if (! extension_loaded('xdebug')) {
@@ -717,9 +662,7 @@ class SessionManagerTest extends TestCase
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testForgetMeShouldSendCookieWithZeroTimestamp(): void
     {
         if (! extension_loaded('xdebug')) {
@@ -750,9 +693,7 @@ class SessionManagerTest extends TestCase
         self::assertStringNotContainsString('expires=', $header);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testStartingSessionThatFailsAValidatorShouldRaiseException(): void
     {
         $this->manager = new SessionManager();
@@ -763,9 +704,7 @@ class SessionManagerTest extends TestCase
         $this->manager->start();
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testResumeSessionThatFailsAValidatorShouldRaiseException(): void
     {
         $this->manager = new SessionManager();
@@ -775,9 +714,7 @@ class SessionManagerTest extends TestCase
         $this->manager->start();
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSessionWriteCloseStoresMetadata(): void
     {
         $this->manager = new SessionManager();
@@ -789,9 +726,7 @@ class SessionManagerTest extends TestCase
         self::assertSame($_SESSION['__Laminas'], $metaData);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSessionValidationDoesNotHaltOnNoopListener(): void
     {
         $this->manager   = new SessionManager();
@@ -806,9 +741,7 @@ class SessionManagerTest extends TestCase
         self::assertTrue($validatorCalled);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testProducedSessionManagerWillNotReplaceSessionSuperGlobalValues(): void
     {
         $this->manager   = new SessionManager();
@@ -820,9 +753,7 @@ class SessionManagerTest extends TestCase
         self::assertSame('bar', $_SESSION['foo']);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testValidatorChainSessionMetadataIsPreserved(): void
     {
         $this->manager = new SessionManager();
@@ -838,9 +769,7 @@ class SessionManagerTest extends TestCase
         self::assertEquals('', $_SESSION['__Laminas']['_VALID'][RemoteAddr::class]);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRemoteAddressValidationWillFailOnInvalidAddress(): void
     {
         $this->manager = new SessionManager();
@@ -852,9 +781,7 @@ class SessionManagerTest extends TestCase
         $this->manager->start();
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRemoteAddressValidationWillSucceedWithValidPreSetData(): void
     {
         $this->manager = new SessionManager();
@@ -871,9 +798,7 @@ class SessionManagerTest extends TestCase
         self::assertTrue($this->manager->isValid());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testRemoteAddressValidationWillFailWithInvalidPreSetData(): void
     {
         $this->manager = new SessionManager();
@@ -890,9 +815,7 @@ class SessionManagerTest extends TestCase
         $this->manager->start();
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testIdValidationWillFailOnInvalidData(): void
     {
         $this->manager = new SessionManager();
@@ -905,6 +828,7 @@ class SessionManagerTest extends TestCase
     }
 
     #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
     public function testSettingTheIdentifierBeforeStartingTheSessionYieldsTheExpectedId(): void
     {
         $manager = new SessionManager();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

Fixes #97 

### Description

In Release 2.22.0 the check for the Constant SID was removed. This lead to the error that the Session could not be started when a session ID was set.
