### PR TITLE
Check for SaveHandlerInterface in the container and use that if set

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -666,14 +666,6 @@
     <DeprecatedInterface>
       <code><![CDATA[SessionConfigFactory]]></code>
     </DeprecatedInterface>
-    <MixedArgument>
-      <code><![CDATA[$config]]></code>
-      <code><![CDATA[$config['config_class']]]></code>
-      <code><![CDATA[$config['config_class']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$config]]></code>
-    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -3,6 +3,7 @@
 namespace Laminas\Session\Config;
 
 use Laminas\Session\Exception;
+use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use SessionHandlerInterface;
 
 use function array_merge;

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -88,8 +88,10 @@ class SessionConfig extends StandardConfig
      * Name of the save handler currently in use. This will either be a PHP
      * built-in save handler name, or the name of a SessionHandlerInterface
      * class being used as a save handler.
+     *
+     * @var null|string|SaveHandlerInterface
      */
-    protected null|string|SaveHandlerInterface $saveHandler = null;
+    protected $saveHandler;
 
     /** @var string session.serialize_handler */
     protected $serializeHandler;

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -87,10 +87,8 @@ class SessionConfig extends StandardConfig
      * Name of the save handler currently in use. This will either be a PHP
      * built-in save handler name, or the name of a SessionHandlerInterface
      * class being used as a save handler.
-     *
-     * @var null|string
      */
-    protected $saveHandler;
+    protected null|string|SaveHandlerInterface $saveHandler = null;
 
     /** @var string session.serialize_handler */
     protected $serializeHandler;

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -11,6 +11,7 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SameSiteCookieCapableInterface;
 use Laminas\Session\Config\SessionConfig;
+use Laminas\Session\SaveHandler\SaveHandlerInterface;
 
 use function class_exists;
 use function is_array;
@@ -53,6 +54,22 @@ class SessionConfigFactory implements FactoryInterface
             }
             $class = $config['config_class'];
             unset($config['config_class']);
+        }
+
+        if (
+            $container->has(SaveHandlerInterface::class) &&
+            (! isset($config['save_handler']) || $config['save_handler'] === SaveHandlerInterface::class)
+        ) {
+            $saveHandler = $container->get(SaveHandlerInterface::class);
+            if (! $saveHandler instanceof SaveHandlerInterface) {
+                throw new ServiceNotCreatedException(sprintf(
+                    'Class %s set as save_handler must implement %s; received "%s"',
+                    SaveHandlerInterface::class,
+                    get_debug_type($saveHandler)
+                ));
+            }
+
+            $config['save_handler'] = $saveHandler;
         }
 
         $sessionConfig = new $class();

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -47,8 +47,8 @@ class SessionConfigFactory implements FactoryInterface
 
         /** @var array{
          *     config_class?: string,
-         *     save_handler?:string|SaveHandlerInterface,
-         *     cookie_samesite:string
+         *     save_handler?: string|SaveHandlerInterface,
+         *     cookie_samesite: string
          * } $config
          */
         $config = $config['session_config'];
@@ -65,8 +65,8 @@ class SessionConfigFactory implements FactoryInterface
         }
 
         if (
-            $container->has(SaveHandlerInterface::class) &&
-            (! isset($config['save_handler']) || $config['save_handler'] === SaveHandlerInterface::class)
+            $container->has(SaveHandlerInterface::class)
+            && (! isset($config['save_handler']) || $config['save_handler'] === SaveHandlerInterface::class)
         ) {
             $saveHandler = $container->get(SaveHandlerInterface::class);
             if (! $saveHandler instanceof SaveHandlerInterface) {

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -64,15 +64,25 @@ class SessionConfigFactory implements FactoryInterface
             unset($config['config_class']);
         }
 
-        if (
-            $container->has(SaveHandlerInterface::class)
-            && (! isset($config['save_handler']) || $config['save_handler'] === SaveHandlerInterface::class)
-        ) {
-            $saveHandler = $container->get(SaveHandlerInterface::class);
+        // We set SaveHandlerInterface as default save_handler if it exists in the container, we do this
+        // because SessionManagerFactory does this, and this keeps the configuration consistent
+        if (! isset($config['save_handler']) && $container->has(SaveHandlerInterface::class)) {
+            $config['save_handler'] = SaveHandlerInterface::class;
+        }
+
+        if (isset($config['save_handler']) && $config['save_handler'] === SaveHandlerInterface::class) {
+            if (! $container->has($config['save_handler'])) {
+                throw new ServiceNotCreatedException(sprintf(
+                    'Class %s set as save_handler must be defined in the service manager',
+                    $config['save_handler']
+                ));
+            }
+
+            $saveHandler = $container->get($config['save_handler']);
             if (! $saveHandler instanceof SaveHandlerInterface) {
                 throw new ServiceNotCreatedException(sprintf(
                     'Class %s set as save_handler must implement %s; received "%s"',
-                    SaveHandlerInterface::class,
+                    $saveHandler::class,
                     SaveHandlerInterface::class,
                     get_debug_type($saveHandler)
                 ));

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -14,6 +14,7 @@ use Laminas\Session\Config\SessionConfig;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
 
 use function class_exists;
+use function get_debug_type;
 use function is_array;
 use function sprintf;
 
@@ -42,7 +43,14 @@ class SessionConfigFactory implements FactoryInterface
             );
         }
 
-        $class  = SessionConfig::class;
+        $class = SessionConfig::class;
+
+        /** @var array{
+         *     config_class?: string,
+         *     save_handler?:string|SaveHandlerInterface,
+         *     cookie_samesite:string
+         * } $config
+         */
         $config = $config['session_config'];
         if (isset($config['config_class'])) {
             if (! class_exists($config['config_class'])) {
@@ -64,6 +72,7 @@ class SessionConfigFactory implements FactoryInterface
             if (! $saveHandler instanceof SaveHandlerInterface) {
                 throw new ServiceNotCreatedException(sprintf(
                     'Class %s set as save_handler must implement %s; received "%s"',
+                    SaveHandlerInterface::class,
                     SaveHandlerInterface::class,
                     get_debug_type($saveHandler)
                 ));

--- a/test/Service/SessionConfigFactoryTest.php
+++ b/test/Service/SessionConfigFactoryTest.php
@@ -22,6 +22,8 @@ use function session_save_path;
 use function session_status;
 use function session_write_close;
 
+use const PHP_SESSION_ACTIVE;
+
 /**
  * @covers \Laminas\Session\Service\SessionConfigFactory
  */
@@ -50,8 +52,12 @@ class SessionConfigFactoryTest extends TestCase
 
     protected function tearDown(): void
     {
-        ini_set('session.save_handler', $this->originalSaveHandler);
-        session_save_path($this->originalSavePath);
+        if ($this->originalSaveHandler) {
+            ini_set('session.save_handler', $this->originalSaveHandler);
+        }
+        if ($this->originalSavePath) {
+            session_save_path($this->originalSavePath);
+        }
     }
 
     public function testCreatesSessionConfigByDefault(): void
@@ -145,8 +151,11 @@ class SessionConfigFactoryTest extends TestCase
             ->willReturn(true);
 
         $factory = new SessionConfigFactory();
-        $config  = $factory($mockContainer, ConfigInterface::class);
+        /** @var SessionConfig $config */
+        $config = $factory($mockContainer, ConfigInterface::class);
 
+        self::assertInstanceOf(SessionConfig::class, $config);
+        /** @noinspection PhpUndefinedMethodInspection This will always exist in SessionConfig */
         self::assertSame($saveHandler::class, $config->getSaveHandler());
         self::assertSame('user', ini_get('session.save_handler'));
         self::assertSame($savePath, session_save_path());
@@ -177,6 +186,8 @@ class SessionConfigFactoryTest extends TestCase
         $factory = new SessionConfigFactory();
         $config  = $factory($mockContainer, ConfigInterface::class);
 
+        self::assertInstanceOf(SessionConfig::class, $config);
+        /** @noinspection PhpUndefinedMethodInspection This will always exist in SessionConfig */
         self::assertSame($saveHandler::class, $config->getSaveHandler());
         self::assertSame('user', ini_get('session.save_handler'));
         self::assertSame($savePath, session_save_path());

--- a/test/Service/SessionConfigFactoryTest.php
+++ b/test/Service/SessionConfigFactoryTest.php
@@ -52,10 +52,11 @@ class SessionConfigFactoryTest extends TestCase
 
     protected function tearDown(): void
     {
-        if ($this->originalSaveHandler) {
+        if ($this->originalSaveHandler !== false) {
             ini_set('session.save_handler', $this->originalSaveHandler);
         }
-        if ($this->originalSavePath) {
+        if ($this->originalSavePath !== false && $this->originalSavePath !== '') {
+            /** @psalm-suppress UnusedFunctionCall */
             session_save_path($this->originalSavePath);
         }
     }

--- a/test/Service/SessionConfigFactoryTest.php
+++ b/test/Service/SessionConfigFactoryTest.php
@@ -9,9 +9,18 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SessionConfig;
 use Laminas\Session\Config\StandardConfig;
+use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\Service\SessionConfigFactory;
 use LaminasTest\Session\TestAsset\TestConfig;
+use LaminasTest\Session\TestAsset\TestSaveHandler;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+use function ini_get;
+use function ini_set;
+use function session_save_path;
+use function session_status;
+use function session_write_close;
 
 /**
  * @covers \Laminas\Session\Service\SessionConfigFactory
@@ -20,13 +29,29 @@ class SessionConfigFactoryTest extends TestCase
 {
     private ServiceManager $services;
 
+    private string|false $originalSaveHandler;
+
+    private string|false $originalSavePath;
+
     protected function setUp(): void
     {
-        $this->services = new ServiceManager([
+        $this->originalSaveHandler = ini_get('session.save_handler');
+        $this->originalSavePath    = session_save_path();
+        $this->services            = new ServiceManager([
             'factories' => [
                 ConfigInterface::class => SessionConfigFactory::class,
             ],
         ]);
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('session.save_handler', $this->originalSaveHandler);
+        session_save_path($this->originalSavePath);
     }
 
     public function testCreatesSessionConfigByDefault(): void
@@ -86,5 +111,74 @@ class SessionConfigFactoryTest extends TestCase
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('"cookie_samesite"');
         $this->services->get(ConfigInterface::class);
+    }
+
+    public function testCanCreateSaveHandlerServiceAndPathViaConfig(): void
+    {
+        $saveHandler   = new TestSaveHandler();
+        $savePath      = 'not_a_directory';
+        $mockContainer = $this->getMockBuilder(ContainerInterface::class)
+            ->onlyMethods(['get', 'has'])
+            ->getMock();
+
+        $mockContainer->expects(self::exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                [
+                    'config',
+                    [
+                        'session_config' => [
+                            'save_handler' => SaveHandlerInterface::class,
+                            'save_path'    => $savePath,
+                        ],
+                    ],
+                ],
+                [
+                    SaveHandlerInterface::class,
+                    $saveHandler,
+                ],
+            ]);
+
+        $mockContainer->expects(self::once())
+            ->method('has')
+            ->with(SaveHandlerInterface::class)
+            ->willReturn(true);
+
+        $factory = new SessionConfigFactory();
+        $config  = $factory($mockContainer, ConfigInterface::class);
+
+        self::assertSame($saveHandler::class, $config->getSaveHandler());
+        self::assertSame('user', ini_get('session.save_handler'));
+        self::assertSame($savePath, session_save_path());
+    }
+
+    public function testCanCreateSaveHandlerAndPathViaConfig(): void
+    {
+        $saveHandler   = new TestSaveHandler();
+        $savePath      = 'not_a_directory';
+        $mockContainer = $this->getMockBuilder(ContainerInterface::class)
+                              ->onlyMethods(['get', 'has'])
+                              ->getMock();
+
+        $mockContainer->expects(self::once())
+                      ->method('get')
+                      ->willReturnMap([
+                          [
+                              'config',
+                              [
+                                  'session_config' => [
+                                      'save_handler' => TestSaveHandler::class,
+                                      'save_path'    => $savePath,
+                                  ],
+                              ],
+                          ],
+                      ]);
+
+        $factory = new SessionConfigFactory();
+        $config  = $factory($mockContainer, ConfigInterface::class);
+
+        self::assertSame($saveHandler::class, $config->getSaveHandler());
+        self::assertSame('user', ini_get('session.save_handler'));
+        self::assertSame($savePath, session_save_path());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | kinda
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

#### My use case
I have a custom laminas session save handler that wraps Googles Firestore save handler. This uses session.save_path for the namespace it uses within the Firestore DB.

so, I configure:
- config option `'session_config' => [ 'save_path' => 'someNamespace']`
- register my custom save handler factory as `Laminas\Session\SaveHandler\SaveHandlerInterface` in ServiceManager as i see that the SessionManager class checks for this and registers it if it exists.

#### The problem
`Laminas\Session\Config\SessionConfig` still requires save_path to exist as a writeable directory, even though the session will start with a `user` save handler due to `SaveHandlerInterface` being registered.
This is because `SessionConfig` class has its own save_handler config option that registers its own custom save handler and only then will it allow save_path not exist locally.
I can't use this config option, as it does not create the save handler from the service manager, and is impossible to inject any dependancies into it. The firestore save handler needs the firestore client injected.

#### Suggested improvement
If a `SaveHandlerInterface`  class is registered in the service manager, and either `'session_config' => 'save_handler' => 'xxx'` is _not_ set, or set to `SaveHandlerInterface::class`, then it will be retrieved from the service container and its instance set as the save_handler. SessionConfig class is already written to handle this, so the only change required is in the factory.

I don't believe it's a BC break, as if its not in the container, it behaves as before. And SessionManager will currently overwrite any save_handler set by SessionConfig if SaveHandlerInterface is set in the service container, so it will not change any other existing configurations or behaviour

