### PR TITLE
Update laminas dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.phpcs-cache
-/.phpunit.result.cache
+/.phpunit.cache
 /docs/html/
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/

--- a/composer.json
+++ b/composer.json
@@ -34,17 +34,17 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "laminas/laminas-eventmanager": "^3.12",
-        "laminas/laminas-servicemanager": "^3.22",
+        "laminas/laminas-servicemanager": "^3.22 || ^4.0",
         "laminas/laminas-stdlib": "^3.18"
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "laminas/laminas-cache": "^3.12.2",
-        "laminas/laminas-cache-storage-adapter-memory": "^2.3",
+        "laminas/laminas-cache": "^4.1",
+        "laminas/laminas-cache-storage-adapter-memory": "^3.0",
         "laminas/laminas-coding-standard": "~3.0.1",
         "laminas/laminas-db": "^2.20.0",
         "laminas/laminas-http": "^2.20",
-        "laminas/laminas-validator": "^2.64.1",
+        "laminas/laminas-validator": "^3.0.1",
         "mongodb/mongodb": "~1.20.0",
         "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.19.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9943744831bb14dff530fc6d4b31fb2",
+    "content-hash": "3ca2131af8866898ff14789ef5be9b51",
     "packages": [
+        {
+            "name": "brick/varexporter",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "vimeo/psalm": "5.15.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-01T21:10:07+00:00"
+        },
         {
             "name": "laminas/laminas-eventmanager",
             "version": "3.14.0",
@@ -76,59 +125,58 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.23.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b"
+                "reference": "b87a792d232c006eec9787230f611c74cc57b8b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a8640182b892b99767d54404d19c5c3b3699f79b",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b87a792d232c006eec9787230f611c74cc57b8b6",
+                "reference": "b87a792d232c006eec9787230f611c74cc57b8b6",
                 "shasum": ""
             },
             "require": {
+                "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0",
                 "laminas/laminas-stdlib": "^3.19",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1 || ^2.0"
             },
             "conflict": {
-                "ext-psr": "*",
                 "laminas/laminas-code": "<4.10.0",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
+                "zendframework/zend-code": "<3.3.1"
             },
             "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
+                "psr/container-implementation": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "boesing/psalm-plugin-stringf": "^1.4",
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "friendsofphp/proxy-manager-lts": "^1.0.18",
-                "laminas/laminas-code": "^4.14.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-cli": "^1.8",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "laminas/laminas-container-config-test": "^1.0",
+                "lctrs/psalm-psr-container-plugin": "^1.9",
                 "mikey179/vfsstream": "^1.6.12",
                 "phpbench/phpbench": "^1.3.1",
                 "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.18.4",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "symfony/console": "^6.0",
                 "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
-                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
+                "laminas/laminas-cli": "To consume CLI commands provided by this component"
             },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ServiceManager",
+                    "config-provider": "Laminas\\ServiceManager\\ConfigProvider"
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -150,11 +198,9 @@
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.3.0"
             },
             "funding": [
                 {
@@ -162,7 +208,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-28T21:32:16+00:00"
+            "time": "2024-11-05T00:35:06+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -224,23 +270,84 @@
             "time": "2024-10-29T13:46:07+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.1.2",
+            "name": "nikic/php-parser",
+            "version": "v4.19.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
+            },
+            "time": "2024-09-29T15:01:53+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -267,9 +374,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         }
     ],
     "packages-dev": [
@@ -1056,31 +1163,30 @@
         },
         {
             "name": "laminas/laminas-cache",
-            "version": "3.12.2",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "f99d10dd1f13d5163a924f8561e9dca3d27d8ad2"
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/f99d10dd1f13d5163a924f8561e9dca3d27d8ad2",
-                "reference": "f99d10dd1f13d5163a924f8561e9dca3d27d8ad2",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/557c34091fdee1791bc16ddc06af583f94caa2dd",
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-cache-storage-implementation": "1.0",
                 "laminas/laminas-eventmanager": "^3.4",
-                "laminas/laminas-servicemanager": "^3.21",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "psr/cache": "^1.0",
+                "laminas/laminas-servicemanager": "^4.1",
+                "laminas/laminas-stdlib": "^3.20",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/cache": "^2.0 || ^3.0",
                 "psr/clock": "^1.0",
-                "psr/simple-cache": "^1.0",
-                "webmozart/assert": "^1.9"
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "webmozart/assert": "^1.11"
             },
             "conflict": {
-                "stella-maris/clock": "<0.1.7",
+                "laminas/laminas-serializer": "<3.0",
                 "symfony/console": "<5.1"
             },
             "provide": {
@@ -1088,20 +1194,13 @@
                 "psr/simple-cache-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-apcu": "^2.4",
-                "laminas/laminas-cache-storage-adapter-blackhole": "^2.3",
-                "laminas/laminas-cache-storage-adapter-filesystem": "^2.3",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2",
-                "laminas/laminas-cache-storage-adapter-test": "^2.4",
-                "laminas/laminas-cli": "^1.7",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-config-aggregator": "^1.13",
-                "laminas/laminas-feed": "^2.20",
-                "laminas/laminas-serializer": "^2.14",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.4"
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-config-aggregator": "^1.17",
+                "laminas/laminas-serializer": "^3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
@@ -1153,38 +1252,38 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-06-14T13:39:14+00:00"
+            "time": "2024-11-26T08:07:17+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
-            "version": "2.3.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
-                "reference": "d2c357a8b839ceb0e0781d5e9aebe46642dbf0b2"
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/d2c357a8b839ceb0e0781d5e9aebe46642dbf0b2",
-                "reference": "d2c357a8b839ceb0e0781d5e9aebe46642dbf0b2",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/10f0d64c0b3e381a8baaca108803111aa7b110db",
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-cache": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "laminas/laminas-servicemanager": "<3.11"
+                "laminas/laminas-cache": "^4.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
             },
             "provide": {
-                "laminas/laminas-cache-storage-implementation": "1.0"
+                "laminas/laminas-cache-storage-implementation": "2.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-benchmark": "^1.1.0",
-                "laminas/laminas-cache-storage-adapter-test": "^2.3.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^4.29.0"
+                "laminas/laminas-cache-storage-adapter-benchmark": "^2.0",
+                "laminas/laminas-cache-storage-adapter-test": "^4.1",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "lcobucci/clock": "^3.0",
+                "lctrs/psalm-psr-container-plugin": "^1.10",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.24"
             },
             "type": "library",
             "extra": {
@@ -1220,7 +1319,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-18T09:43:33+00:00"
+            "time": "2024-11-27T08:14:09+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1531,6 +1630,59 @@
             "time": "2024-12-05T14:43:32+00:00"
         },
         {
+            "name": "laminas/laminas-translator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-21T15:33:01+00:00"
+        },
+        {
             "name": "laminas/laminas-uri",
             "version": "2.13.0",
             "source": {
@@ -1590,49 +1742,43 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.64.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "771e504760448ac7af660710237ceb93be602e08"
+                "reference": "ab6f4564360edba978d6b5082dc99cea2bd9bdef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
-                "reference": "771e504760448ac7af660710237ceb93be602e08",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ab6f4564360edba978d6b5082dc99cea2bd9bdef",
+                "reference": "ab6f4564360edba978d6b5082dc99cea2bd9bdef",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-servicemanager": "^3.21.0",
+                "ext-ctype": "*",
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^4.1.0",
                 "laminas/laminas-stdlib": "^3.19",
+                "laminas/laminas-translator": "^1.0",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/http-message": "^1.0.1 || ^2.0.0"
-            },
-            "conflict": {
-                "zendframework/zend-validator": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5",
-                "laminas/laminas-db": "^2.20",
-                "laminas/laminas-filter": "^2.35.2",
-                "laminas/laminas-i18n": "^2.26.0",
-                "laminas/laminas-session": "^2.20",
-                "laminas/laminas-uri": "^2.11.0",
-                "phpunit/phpunit": "^10.5.20",
-                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/container": "^1.1 || ^2.0",
                 "psr/http-client": "^1.0.3",
                 "psr/http-factory": "^1.1.0",
-                "vimeo/psalm": "^5.24.0"
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-diactoros": "^3.5.0",
+                "maglnet/composer-require-checker": "^4.7.1",
+                "phpunit/phpunit": "^10.5.37",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
-                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
-                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-                "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
-                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
-                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+                "laminas/laminas-i18n-resources": "Translations of validator messages"
             },
             "type": "library",
             "extra": {
@@ -1670,7 +1816,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-26T21:29:17+00:00"
+            "time": "2024-11-29T09:36:29+00:00"
         },
         {
             "name": "mongodb/mongodb",
@@ -1859,62 +2005,6 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
             },
             "time": "2024-09-08T10:13:13+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.19.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
-            },
-            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2740,20 +2830,20 @@
         },
         {
             "name": "psr/cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
@@ -2773,7 +2863,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -2783,9 +2873,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/clock",
@@ -2834,6 +2924,113 @@
                 "source": "https://github.com/php-fig/clock/tree/1.0.0"
             },
             "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2940,25 +3137,25 @@
         },
         {
             "name": "psr/simple-cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2973,7 +3170,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for simple caching",
@@ -2985,9 +3182,9 @@
                 "simple-cache"
             ],
             "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
-            "time": "2017-10-23T01:57:42+00:00"
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -278,9 +278,6 @@
       <code><![CDATA[null|string]]></code>
       <code><![CDATA[string|null]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument>
-      <code><![CDATA[HostnameValidator::ALLOW_ALL]]></code>
-    </InvalidArgument>
     <InvalidReturnType>
       <code><![CDATA[mixed]]></code>
     </InvalidReturnType>
@@ -460,9 +457,6 @@
       <code><![CDATA[$sessionName]]></code>
       <code><![CDATA[$sessionSavePath]]></code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $this->getCacheStorage()->removeItem($id)]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/SaveHandler/DbTableGateway.php">
     <ImplementedReturnTypeMismatch>
@@ -628,13 +622,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Service/ContainerAbstractServiceFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[ContainerAbstractServiceFactory]]></code>
-    </DeprecatedInterface>
-    <MissingConstructor>
-      <code><![CDATA[$config]]></code>
-      <code><![CDATA[$sessionManager]]></code>
-    </MissingConstructor>
     <MixedArgument>
       <code><![CDATA[$config]]></code>
     </MixedArgument>
@@ -644,42 +631,22 @@
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$config]]></code>
-      <code><![CDATA[$this->sessionManager]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[null|ManagerInterface]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->sessionManager]]></code>
-      <code><![CDATA[$this->sessionManager]]></code>
-    </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->sessionManager !== null]]></code>
-      <code><![CDATA[null !== $this->config]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Service/SessionConfigFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[SessionConfigFactory]]></code>
-    </DeprecatedInterface>
+    <MixedArgument>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$config['config_class']]]></code>
+      <code><![CDATA[$config['config_class']]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$config]]></code>
+    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Service/SessionManagerFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[SessionManagerFactory]]></code>
-    </DeprecatedInterface>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$manager]]></code>
-    </LessSpecificReturnStatement>
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$configService]]></code>
@@ -688,17 +655,8 @@
       <code><![CDATA[$storage]]></code>
       <code><![CDATA[$validators]]></code>
     </MixedAssignment>
-    <MoreSpecificReturnType>
-      <code><![CDATA[SessionManager]]></code>
-    </MoreSpecificReturnType>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Service/StorageFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[StorageFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$type]]></code>
@@ -708,9 +666,6 @@
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$type]]></code>
     </MixedAssignment>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/SessionManager.php">
     <DocblockTypeContradiction>
@@ -1439,52 +1394,17 @@
     <MissingReturnType>
       <code><![CDATA[testServiceNotCreatedWhenInvalidSamesiteConfig]]></code>
     </MissingReturnType>
-    <MixedAssignment>
-      <code><![CDATA[$config]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[getName]]></code>
-    </MixedMethodCall>
   </file>
   <file src="test/Service/SessionManagerFactoryTest.php">
-    <MixedArgument>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$manager]]></code>
-    </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$listener[0]]]></code>
       <code><![CDATA[$validatorData[Validator\HttpUserAgent::class]]]></code>
       <code><![CDATA[$validatorData[Validator\RemoteAddr::class]]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$chain]]></code>
       <code><![CDATA[$listener]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
       <code><![CDATA[$validatorData]]></code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[getConfig]]></code>
-      <code><![CDATA[getSaveHandler]]></code>
-      <code><![CDATA[getStorage]]></code>
-      <code><![CDATA[getStorage]]></code>
-      <code><![CDATA[getValidatorChain]]></code>
-      <code><![CDATA[getValidatorChain]]></code>
-      <code><![CDATA[start]]></code>
-      <code><![CDATA[start]]></code>
-      <code><![CDATA[start]]></code>
-    </MixedMethodCall>
     <UnusedVariable>
       <code><![CDATA[$manager]]></code>
       <code><![CDATA[$manager]]></code>
@@ -1495,14 +1415,6 @@
       <code><![CDATA[$config['session_storage']['options']]]></code>
       <code><![CDATA[$config['session_storage']['options']['input']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$storage]]></code>
-      <code><![CDATA[$storage]]></code>
-      <code><![CDATA[$test]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[toArray]]></code>
-    </MixedMethodCall>
     <UnusedVariable>
       <code><![CDATA[$storage]]></code>
     </UnusedVariable>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -634,14 +634,6 @@
     </MixedAssignment>
   </file>
   <file src="src/Service/SessionConfigFactory.php">
-    <MixedArgument>
-      <code><![CDATA[$config]]></code>
-      <code><![CDATA[$config['config_class']]]></code>
-      <code><![CDATA[$config['config_class']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$config]]></code>
-    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>

--- a/src/Config/StandardConfig.php
+++ b/src/Config/StandardConfig.php
@@ -492,7 +492,7 @@ class StandardConfig implements ConfigInterface, SameSiteCookieCapableInterface
             throw new Exception\InvalidArgumentException('Invalid cookie domain: must be a string');
         }
 
-        $validator = new HostnameValidator(HostnameValidator::ALLOW_ALL);
+        $validator = new HostnameValidator(['allow' => HostnameValidator::ALLOW_ALL]);
 
         if (! empty($cookieDomain) && ! $validator->isValid($cookieDomain)) {
             throw new Exception\InvalidArgumentException(

--- a/src/SaveHandler/Cache.php
+++ b/src/SaveHandler/Cache.php
@@ -75,6 +75,7 @@ class Cache implements SaveHandlerInterface
      *
      * @param string $id
      * @return string
+     * @psalm-param non-empty-string $id
      */
     #[ReturnTypeWillChange]
     public function read($id)
@@ -88,6 +89,7 @@ class Cache implements SaveHandlerInterface
      * @param string $id
      * @param string $data
      * @return bool
+     * @psalm-param non-empty-string $id
      */
     #[ReturnTypeWillChange]
     public function write($id, $data)
@@ -100,15 +102,18 @@ class Cache implements SaveHandlerInterface
      *
      * @param string $id
      * @return bool
+     * @psalm-param non-empty-string $id
      */
     #[ReturnTypeWillChange]
     public function destroy($id)
     {
         $this->getCacheStorage()->getItem($id, $exists);
+        /** @psalm-suppress RedundantCast */
         if (! (bool) $exists) {
             return true;
         }
 
+        /** @psalm-suppress RedundantCast */
         return (bool) $this->getCacheStorage()->removeItem($id);
     }
 

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -16,6 +16,7 @@ use function array_flip;
 use function array_key_exists;
 use function get_debug_type;
 use function is_array;
+use function sprintf;
 use function strtolower;
 
 /**

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -7,12 +7,14 @@ namespace Laminas\Session\Service;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Container;
+use Laminas\Session\Exception\RuntimeException;
 use Laminas\Session\ManagerInterface;
 use Psr\Container\ContainerInterface;
 
 use function array_change_key_case;
 use function array_flip;
 use function array_key_exists;
+use function get_debug_type;
 use function is_array;
 use function strtolower;
 
@@ -42,14 +44,14 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     /**
      * Cached container configuration
      */
-    protected array $config;
+    protected ?array $config = null;
 
     /**
      * Configuration key in which session containers live
      */
     protected string $configKey = 'session_containers';
 
-    protected ManagerInterface $sessionManager;
+    protected ?ManagerInterface $sessionManager = null;
 
     /**
      * Can we create an instance of the given service? (v3 usage).
@@ -67,6 +69,8 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Can we create an instance of the given service? (v2 usage)
+     *
+     * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function canCreateServiceWithName(
         ServiceLocatorInterface $container,
@@ -87,6 +91,8 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Create and return a named container (v2 usage).
+     *
+     * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function createServiceWithName(
         ServiceLocatorInterface $container,
@@ -101,7 +107,7 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
      */
     protected function getConfig(ContainerInterface $container): array
     {
-        if (isset($this->config)) {
+        if (is_array($this->config)) {
             return $this->config;
         }
 
@@ -129,12 +135,23 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
      */
     protected function getSessionManager(ContainerInterface $container): ?ManagerInterface
     {
-        if (isset($this->sessionManager)) {
+        if ($this->sessionManager instanceof ManagerInterface) {
             return $this->sessionManager;
         }
 
         if ($container->has(ManagerInterface::class)) {
-            $this->sessionManager = $container->get(ManagerInterface::class);
+            $sessionManager = $container->get(ManagerInterface::class);
+
+            if (! $sessionManager instanceof ManagerInterface) {
+                throw new RuntimeException(sprintf(
+                    '%s service did not map to a %s implementation; received %s',
+                    ManagerInterface::class,
+                    ManagerInterface::class,
+                    get_debug_type($sessionManager)
+                ));
+            }
+
+            $this->sessionManager = $sessionManager;
         }
 
         return $this->sessionManager;

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -4,11 +4,11 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\AbstractFactoryInterface;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Container;
 use Laminas\Session\ManagerInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_change_key_case;
 use function array_flip;
@@ -41,28 +41,20 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 {
     /**
      * Cached container configuration
-     *
-     * @var array
      */
-    protected $config;
+    protected array $config;
 
     /**
      * Configuration key in which session containers live
-     *
-     * @var string
      */
-    protected $configKey = 'session_containers';
+    protected string $configKey = 'session_containers';
 
-    /** @var ManagerInterface */
-    protected $sessionManager;
+    protected ManagerInterface $sessionManager;
 
     /**
      * Can we create an instance of the given service? (v3 usage).
-     *
-     * @param string $requestedName
-     * @return bool
      */
-    public function canCreate(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, string $requestedName): bool
     {
         $config = $this->getConfig($container);
         if ($config === []) {
@@ -75,23 +67,19 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Can we create an instance of the given service? (v2 usage)
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @return bool
      */
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
+    public function canCreateServiceWithName(
+        ServiceLocatorInterface $container,
+        string $name,
+        string $requestedName
+    ): bool {
         return $this->canCreate($container, $requestedName);
     }
 
     /**
      * Create and return a named container (v3 usage).
-     *
-     * @param string $requestedName
-     * @return Container
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): Container
     {
         $manager = $this->getSessionManager($container);
         return new Container($requestedName, $manager);
@@ -99,24 +87,21 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Create and return a named container (v2 usage).
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @return Container
      */
-    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
+    public function createServiceWithName(
+        ServiceLocatorInterface $container,
+        string $name,
+        string $requestedName
+    ): Container {
         return $this($container, $requestedName);
     }
 
     /**
      * Retrieve config from service locator, and cache for later
-     *
-     * @return array
      */
-    protected function getConfig(ContainerInterface $container)
+    protected function getConfig(ContainerInterface $container): array
     {
-        if (null !== $this->config) {
+        if (isset($this->config)) {
             return $this->config;
         }
 
@@ -141,12 +126,10 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Retrieve the session manager instance, if any
-     *
-     * @return null|ManagerInterface
      */
-    protected function getSessionManager(ContainerInterface $container)
+    protected function getSessionManager(ContainerInterface $container): ?ManagerInterface
     {
-        if ($this->sessionManager !== null) {
+        if (isset($this->sessionManager)) {
             return $this->sessionManager;
         }
 
@@ -159,11 +142,8 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Normalize the container name in order to perform a lookup
-     *
-     * @param  string $name
-     * @return string
      */
-    protected function normalizeContainerName($name)
+    protected function normalizeContainerName(string $name): string
     {
         return strtolower($name);
     }

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -4,14 +4,14 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SameSiteCookieCapableInterface;
 use Laminas\Session\Config\SessionConfig;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
+use Psr\Container\ContainerInterface;
 
 use function class_exists;
 use function get_debug_type;
@@ -28,14 +28,14 @@ class SessionConfigFactory implements FactoryInterface
      * you may also specify a specific implementation variant using the
      * "config_class" subkey.
      *
-     * @param string $requestedName
-     * @param null|array $options
-     * @return ConfigInterface
      * @throws ServiceNotCreatedException If session_config is missing, or an
      *     invalid config_class is used.
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): ConfigInterface {
         $config = $container->get('config');
         if (! isset($config['session_config']) || ! is_array($config['session_config'])) {
             throw new ServiceNotCreatedException(
@@ -118,16 +118,12 @@ class SessionConfigFactory implements FactoryInterface
 
     /**
      * Create and return a config instance (v2 usage).
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return ConfigInterface
      */
     public function createService(
         ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = ConfigInterface::class
-    ) {
+        ?string $canonicalName = null,
+        string $requestedName = ConfigInterface::class
+    ): ConfigInterface {
         return $this($services, $requestedName);
     }
 }

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -118,6 +118,7 @@ class SessionConfigFactory implements FactoryInterface
 
     /**
      * Create and return a config instance (v2 usage).
+     * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function createService(
         ServiceLocatorInterface $services,

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -118,6 +118,7 @@ class SessionConfigFactory implements FactoryInterface
 
     /**
      * Create and return a config instance (v2 usage).
+     *
      * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function createService(

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -4,9 +4,8 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Container;
@@ -14,6 +13,7 @@ use Laminas\Session\ManagerInterface;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\SessionManager;
 use Laminas\Session\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_merge;
 use function class_exists;
@@ -26,10 +26,8 @@ class SessionManagerFactory implements FactoryInterface
 {
     /**
      * Default configuration for manager behavior
-     *
-     * @var array
      */
-    protected $defaultManagerConfig = [
+    protected array $defaultManagerConfig = [
         'enable_default_container_manager' => true,
     ];
 
@@ -58,12 +56,12 @@ class SessionManagerFactory implements FactoryInterface
      *   as the default manager for Container instances. The default value for
      *   this is true; set it to false to disable.
      * - validators: ...
-     *
-     * @param string $requestedName
-     * @return SessionManager
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): ManagerInterface|SessionManager {
         $config        = null;
         $storage       = null;
         $saveHandler   = null;
@@ -151,16 +149,12 @@ class SessionManagerFactory implements FactoryInterface
 
     /**
      * Create a SessionManager instance (v2 usage)
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return SessionManager
      */
     public function createService(
         ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = SessionManager::class
-    ) {
+        ?string $canonicalName = null,
+        string $requestedName = SessionManager::class
+    ): ManagerInterface|SessionManager {
         return $this($services, $requestedName);
     }
 }

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -149,6 +149,7 @@ class SessionManagerFactory implements FactoryInterface
 
     /**
      * Create a SessionManager instance (v2 usage)
+     *
      * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function createService(

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -149,6 +149,7 @@ class SessionManagerFactory implements FactoryInterface
 
     /**
      * Create a SessionManager instance (v2 usage)
+     * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function createService(
         ServiceLocatorInterface $services,

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -10,8 +10,8 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Exception\ExceptionInterface as SessionException;
 use Laminas\Session\Storage\Factory;
 use Laminas\Session\Storage\StorageInterface;
-
 use Psr\Container\ContainerInterface;
+
 use function is_array;
 use function sprintf;
 
@@ -28,8 +28,11 @@ class StorageFactory implements FactoryInterface
      * @throws ServiceNotCreatedException If session_storage is missing, or the
      *         factory cannot create the storage instance.
      */
-    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): StorageInterface
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): StorageInterface {
         $config = $container->get('config');
         if (! isset($config['session_storage']) || ! is_array($config['session_storage'])) {
             throw new ServiceNotCreatedException(
@@ -63,10 +66,9 @@ class StorageFactory implements FactoryInterface
      */
     public function createService(
         ServiceLocatorInterface $services,
-        ?string                  $canonicalName = null,
-        string                  $requestedName = StorageInterface::class
-    ): StorageInterface
-    {
+        ?string $canonicalName = null,
+        string $requestedName = StorageInterface::class
+    ): StorageInterface {
         return $this($services, $requestedName);
     }
 }

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -63,6 +63,7 @@ class StorageFactory implements FactoryInterface
 
     /**
      * Create and return a storage instance (v2 usage).
+     * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function createService(
         ServiceLocatorInterface $services,

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -63,6 +63,7 @@ class StorageFactory implements FactoryInterface
 
     /**
      * Create and return a storage instance (v2 usage).
+     *
      * @psalm-suppress PossiblyUnusedMethod,PossiblyUnusedParam
      */
     public function createService(

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -4,14 +4,14 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Exception\ExceptionInterface as SessionException;
 use Laminas\Session\Storage\Factory;
 use Laminas\Session\Storage\StorageInterface;
 
+use Psr\Container\ContainerInterface;
 use function is_array;
 use function sprintf;
 
@@ -25,12 +25,10 @@ class StorageFactory implements FactoryInterface
      * type to use, and optionally "options", containing any options to be used in
      * creating the StorageInterface instance.
      *
-     * @param string $requestedName
-     * @return StorageInterface
      * @throws ServiceNotCreatedException If session_storage is missing, or the
      *         factory cannot create the storage instance.
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): StorageInterface
     {
         $config = $container->get('config');
         if (! isset($config['session_storage']) || ! is_array($config['session_storage'])) {
@@ -62,16 +60,13 @@ class StorageFactory implements FactoryInterface
 
     /**
      * Create and return a storage instance (v2 usage).
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return StorageInterface
      */
     public function createService(
         ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = StorageInterface::class
-    ) {
+        ?string                  $canonicalName = null,
+        string                  $requestedName = StorageInterface::class
+    ): StorageInterface
+    {
         return $this($services, $requestedName);
     }
 }

--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -20,6 +20,7 @@ use function strtr;
 /**
  * @psalm-type OptionsArgument = array{
  *     name?: non-empty-string,
+ *     hash?: non-empty-string,
  *     salt?: non-empty-string,
  *     session?: Container,
  *     timeout?: ?int,

--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -46,33 +46,38 @@ final class Csrf extends AbstractValidator
     /**
      * Actual hash used.
      */
-    private ?string $hash = null;
+    private ?string $hash;
 
     /**
      * Name of CSRF element (used to create non-colliding hashes)
      *
      * @var non-empty-string
      */
-    private string $name = 'csrf';
+    private string $name;
 
     /**
      * Salt for CSRF token
      *
      * @var non-empty-string
      */
-    private string $salt = 'salt';
+    private string $salt;
 
-    private ?Container $session = null;
+    private ?Container $session;
 
     /**
      * TTL for CSRF token
      */
-    private int|null $timeout = 300;
+    private int|null $timeout;
 
     /** @param OptionsArgument $options */
     public function __construct(array $options = [])
     {
         parent::__construct($options);
+        $this->hash    = $options['hash'] ?? null;
+        $this->name    = $options['name'] ?? 'csrf';
+        $this->salt    = $options['salt'] ?? 'salt';
+        $this->session = $options['session'] ?? null;
+        $this->timeout = $options['timeout'] ?? 300;
     }
 
     /**
@@ -128,7 +133,7 @@ final class Csrf extends AbstractValidator
     public function setSession(Container $session): void
     {
         $this->session = $session;
-        if ($this->hash !== null) {
+        if (isset($this->hash)) {
             $this->initCsrfToken();
         }
     }

--- a/test/Service/SessionManagerFactoryTest.php
+++ b/test/Service/SessionManagerFactoryTest.php
@@ -114,7 +114,7 @@ class SessionManagerFactoryTest extends TestCase
 
         $manager->start();
 
-        $chain     = $manager->getValidatorChain();
+        $chain = $manager->getValidatorChain();
         /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
@@ -199,7 +199,7 @@ class SessionManagerFactoryTest extends TestCase
             // Ignore exception, because we are not interested whether session validation passes in this test
         }
 
-        $chain     = $manager->getValidatorChain();
+        $chain = $manager->getValidatorChain();
         /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);

--- a/test/Service/SessionManagerFactoryTest.php
+++ b/test/Service/SessionManagerFactoryTest.php
@@ -115,6 +115,7 @@ class SessionManagerFactoryTest extends TestCase
         $manager->start();
 
         $chain     = $manager->getValidatorChain();
+        /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
     }
@@ -199,6 +200,7 @@ class SessionManagerFactoryTest extends TestCase
         }
 
         $chain     = $manager->getValidatorChain();
+        /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
 


### PR DESCRIPTION
This PR simply updates the laminas dependencies and adapts accordingly the use of the new major versions of laminas-servicemanager and laminas-validator.

I also removed the php annotations and added explicit return types to the modified classes.

This unfortunately breaks backwards compatibility and will require the release of a new major version of laminas-session.
<!--
### Description

<!--
This PR simply updates the laminas dependencies and adapts accordingly the use of the new major versions of laminas-servicemanager and laminas-validator.

I also remove the php annotations and added explicit return types to the modified classes 

-->
