### PR TITLE
Upgrade Service Manager to v4 in `require`, Cache to v4 and Validator to v3 in `require-dev`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.phpcs-cache
-/.phpunit.result.cache
+/.phpunit.cache
 /docs/html/
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,13 @@
         "laminas/laminas-eventmanager": "^3.12",
         "laminas/laminas-servicemanager": "^4.0",
         "laminas/laminas-stdlib": "^3.18",
+        "laminas/laminas-validator": "^3.0",
         "psr/simple-cache": "^3.0"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "laminas/laminas-coding-standard": "~3.0.1",
         "laminas/laminas-http": "^2.20",
-        "laminas/laminas-validator": "^3.0.0",
         "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.19.0",
         "vimeo/psalm": "^5.26.1"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "laminas/laminas-eventmanager": "^3.12",
-        "laminas/laminas-servicemanager": "^3.22",
+        "laminas/laminas-servicemanager": "^4.0",
         "laminas/laminas-stdlib": "^3.18",
         "psr/simple-cache": "^3.0"
     },
@@ -42,7 +42,7 @@
         "ext-xdebug": "*",
         "laminas/laminas-coding-standard": "~3.0.1",
         "laminas/laminas-http": "^2.20",
-        "laminas/laminas-validator": "^2.64.1",
+        "laminas/laminas-validator": "^3.0.0",
         "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.19.0",
         "vimeo/psalm": "^5.26.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6319906222fbfb5f37ac072f41026096",
+    "content-hash": "43bd717738fdabda89cf44c24edb8c1c",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -125,16 +125,16 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "4.3.0",
+            "version": "4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b87a792d232c006eec9787230f611c74cc57b8b6"
+                "reference": "74da44d07e493b834347123242d0047976fb9932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b87a792d232c006eec9787230f611c74cc57b8b6",
-                "reference": "b87a792d232c006eec9787230f611c74cc57b8b6",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/74da44d07e493b834347123242d0047976fb9932",
+                "reference": "74da44d07e493b834347123242d0047976fb9932",
                 "shasum": ""
             },
             "require": {
@@ -151,19 +151,17 @@
                 "psr/container-implementation": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "boesing/psalm-plugin-stringf": "^1.4",
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "friendsofphp/proxy-manager-lts": "^1.0.18",
-                "laminas/laminas-cli": "^1.8",
-                "laminas/laminas-coding-standard": "~3.0.0",
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
                 "laminas/laminas-container-config-test": "^1.0",
-                "lctrs/psalm-psr-container-plugin": "^1.9",
                 "mikey179/vfsstream": "^1.6.12",
-                "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "symfony/console": "^6.0",
-                "vimeo/psalm": "^5.26.1"
+                "phpbench/phpbench": "^1.4.0",
+                "phpunit/phpunit": "^10.5.44",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "symfony/console": "^6.4.17 || ^7.0",
+                "vimeo/psalm": "^6.2.0"
             },
             "suggest": {
                 "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
@@ -200,7 +198,7 @@
                 "chat": "https://laminas.dev/chat",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.3.0"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.4.0"
             },
             "funding": [
                 {
@@ -208,7 +206,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-05T00:35:06+00:00"
+            "time": "2025-02-04T06:13:50+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -268,6 +266,136 @@
                 }
             ],
             "time": "2024-10-29T13:46:07+00:00"
+        },
+        {
+            "name": "laminas/laminas-translator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-21T15:33:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "5d648b3ac54ef50714009cd3e9d4b1acd5c339e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/5d648b3ac54ef50714009cd3e9d4b1acd5c339e6",
+                "reference": "5d648b3ac54ef50714009cd3e9d4b1acd5c339e6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^4.1.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "laminas/laminas-translator": "^1.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/container": "^1.1 || ^2.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-diactoros": "^3.5.0",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.0"
+            },
+            "suggest": {
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-validator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-validator/issues",
+                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
+                "source": "https://github.com/laminas/laminas-validator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-04-28T08:03:29+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -377,6 +505,217 @@
                 "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
             "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         }
     ],
     "packages-dev": [
@@ -956,26 +1295,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9"
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/31610dbb31faa98e6b5447b62340826f54fbc4e9",
-                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12",
-                "phpstan/phpstan": "1.4.10 || 2.0.3",
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -995,9 +1337,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
-            "time": "2024-12-07T21:18:45+00:00"
+            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1160,166 +1502,6 @@
                 }
             ],
             "time": "2024-08-06T10:04:20+00:00"
-        },
-        {
-            "name": "laminas/laminas-cache",
-            "version": "4.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/557c34091fdee1791bc16ddc06af583f94caa2dd",
-                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-eventmanager": "^3.4",
-                "laminas/laminas-servicemanager": "^4.1",
-                "laminas/laminas-stdlib": "^3.20",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/cache": "^2.0 || ^3.0",
-                "psr/clock": "^1.0",
-                "psr/simple-cache": "^2.0 || ^3.0",
-                "webmozart/assert": "^1.11"
-            },
-            "conflict": {
-                "laminas/laminas-serializer": "<3.0",
-                "symfony/console": "<5.1"
-            },
-            "provide": {
-                "psr/cache-implementation": "1.0",
-                "psr/simple-cache-implementation": "1.0"
-            },
-            "require-dev": {
-                "laminas/laminas-cli": "^1.11",
-                "laminas/laminas-coding-standard": "~3.0.1",
-                "laminas/laminas-config-aggregator": "^1.17",
-                "laminas/laminas-serializer": "^3.1",
-                "phpunit/phpunit": "^10.5.38",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
-            },
-            "suggest": {
-                "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
-                "laminas/laminas-cache-storage-adapter-blackhole": "Blackhole/Void implementation",
-                "laminas/laminas-cache-storage-adapter-ext-mongodb": "MongoDB implementation",
-                "laminas/laminas-cache-storage-adapter-filesystem": "Filesystem implementation",
-                "laminas/laminas-cache-storage-adapter-memcached": "Memcached implementation",
-                "laminas/laminas-cache-storage-adapter-memory": "Memory implementation",
-                "laminas/laminas-cache-storage-adapter-redis": "Redis implementation",
-                "laminas/laminas-cache-storage-adapter-session": "Session implementation",
-                "laminas/laminas-cli": "The laminas-cli binary can be used to consume commands provided by this component",
-                "laminas/laminas-serializer": "Laminas\\Serializer component"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Cache",
-                    "config-provider": "Laminas\\Cache\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Caching implementation with a variety of storage options, as well as codified caching strategies for callbacks, classes, and output",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "cache",
-                "laminas",
-                "psr-16",
-                "psr-6"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-cache/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-cache/issues",
-                "rss": "https://github.com/laminas/laminas-cache/releases.atom",
-                "source": "https://github.com/laminas/laminas-cache"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-01-21T12:32:41+00:00"
-        },
-        {
-            "name": "laminas/laminas-cache-storage-adapter-memory",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
-                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/10f0d64c0b3e381a8baaca108803111aa7b110db",
-                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-cache": "^4.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/clock": "^1.0"
-            },
-            "provide": {
-                "laminas/laminas-cache-storage-implementation": "2.0"
-            },
-            "require-dev": {
-                "laminas/laminas-cache-storage-adapter-benchmark": "^2.0",
-                "laminas/laminas-cache-storage-adapter-test": "^4.1",
-                "laminas/laminas-coding-standard": "~3.0.0",
-                "lcobucci/clock": "^3.0",
-                "lctrs/psalm-psr-container-plugin": "^1.10",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.24"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\Cache\\Storage\\Adapter\\Memory",
-                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Memory\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Cache\\Storage\\Adapter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Laminas cache adapter for memory",
-            "keywords": [
-                "cache",
-                "laminas"
-            ],
-            "support": {
-                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memory/",
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memory/issues",
-                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memory/releases.atom",
-                "source": "https://github.com/laminas/laminas-cache-storage-adapter-memory"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-11-27T08:14:09+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1558,59 +1740,6 @@
             "time": "2024-12-05T14:43:32+00:00"
         },
         {
-            "name": "laminas/laminas-translator",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-translator.git",
-                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/12897e710e21413c1f93fc38fe9dead6b51c5218",
-                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0.0",
-                "vimeo/psalm": "^5.24.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Translator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Interfaces for the Translator component of laminas-i18n",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "i18n",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-i18n/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-translator/issues",
-                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
-                "source": "https://github.com/laminas/laminas-translator"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-10-21T15:33:01+00:00"
-        },
-        {
             "name": "laminas/laminas-uri",
             "version": "2.13.0",
             "source": {
@@ -1669,95 +1798,17 @@
             "time": "2024-12-03T12:27:51+00:00"
         },
         {
-            "name": "laminas/laminas-validator",
-            "version": "3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "ab6f4564360edba978d6b5082dc99cea2bd9bdef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ab6f4564360edba978d6b5082dc99cea2bd9bdef",
-                "reference": "ab6f4564360edba978d6b5082dc99cea2bd9bdef",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-fileinfo": "*",
-                "ext-filter": "*",
-                "ext-intl": "*",
-                "laminas/laminas-servicemanager": "^4.1.0",
-                "laminas/laminas-stdlib": "^3.19",
-                "laminas/laminas-translator": "^1.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/container": "^1.1 || ^2.0",
-                "psr/http-client": "^1.0.3",
-                "psr/http-factory": "^1.1.0",
-                "psr/http-message": "^1.0.1 || ^2.0.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^3.0.1",
-                "laminas/laminas-diactoros": "^3.5.0",
-                "maglnet/composer-require-checker": "^4.7.1",
-                "phpunit/phpunit": "^10.5.37",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
-            },
-            "suggest": {
-                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-                "laminas/laminas-i18n-resources": "Translations of validator messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Validator",
-                    "config-provider": "Laminas\\Validator\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Validator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "validator"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-validator/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-validator/issues",
-                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
-                "source": "https://github.com/laminas/laminas-validator"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-11-29T09:36:29+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -1796,7 +1847,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -1804,7 +1855,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2030,16 +2081,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.1",
+            "version": "5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8"
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/92dde6a5919e34835c506ac8c523ef095a95ed62",
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62",
                 "shasum": ""
             },
             "require": {
@@ -2088,9 +2139,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.2"
             },
-            "time": "2024-12-07T09:39:29+00:00"
+            "time": "2025-04-13T19:20:35+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2680,263 +2731,6 @@
             "time": "2024-03-15T10:43:15+00:00"
         },
         {
-            "name": "psr/cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
-            },
-            "time": "2021-02-03T23:26:27+00:00"
-        },
-        {
-            "name": "psr/clock",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/clock.git",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Clock\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for reading the clock.",
-            "homepage": "https://github.com/php-fig/clock",
-            "keywords": [
-                "clock",
-                "now",
-                "psr",
-                "psr-20",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/clock/issues",
-                "source": "https://github.com/php-fig/clock/tree/1.0.0"
-            },
-            "time": "2022-11-25T14:36:26+00:00"
-        },
-        {
-            "name": "psr/http-client",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client"
-            },
-            "time": "2023-09-23T14:17:50+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory"
-            },
-            "time": "2024-04-15T12:06:14+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
             "name": "psr/log",
             "version": "3.0.2",
             "source": {
@@ -2985,57 +2779,6 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3955,32 +3698,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.16.2",
+            "version": "8.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "8bf0408a9cf30687d87957d364de9a3d5d00d948"
+                "reference": "9bad414288a59cd5bc55f9a4042784431fb18b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/8bf0408a9cf30687d87957d364de9a3d5d00d948",
-                "reference": "8bf0408a9cf30687d87957d364de9a3d5d00d948",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/9bad414288a59cd5bc55f9a4042784431fb18b8c",
+                "reference": "9bad414288a59cd5bc55f9a4042784431fb18b8c",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": "^7.4 || ^8.0",
                 "phpstan/phpdoc-parser": "^2.1.0",
-                "squizlabs/php_codesniffer": "^3.11.3"
+                "squizlabs/php_codesniffer": "^3.12.2"
             },
             "require-dev": {
                 "phing/phing": "3.0.1",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.11",
+                "phpstan/phpstan": "2.1.12",
                 "phpstan/phpstan-deprecation-rules": "2.0.1",
                 "phpstan/phpstan-phpunit": "2.0.6",
                 "phpstan/phpstan-strict-rules": "2.0.4",
-                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.15|12.0.10"
+                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.17|12.1.3"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4004,7 +3747,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.16.2"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.17.1"
             },
             "funding": [
                 {
@@ -4016,7 +3759,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T19:37:58+00:00"
+            "time": "2025-04-25T18:38:26+00:00"
         },
         {
             "name": "spatie/array-to-xml",
@@ -4088,16 +3831,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.0",
+            "version": "3.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
-                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
                 "shasum": ""
             },
             "require": {
@@ -4168,7 +3911,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-03-18T05:04:51+00:00"
+            "time": "2025-04-13T04:10:18+00:00"
         },
         {
             "name": "symfony/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1d72388b1b25b7c75bb8a1711a03ea2",
+    "content-hash": "6319906222fbfb5f37ac072f41026096",
     "packages": [
+        {
+            "name": "brick/varexporter",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "vimeo/psalm": "5.15.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-01T21:10:07+00:00"
+        },
         {
             "name": "laminas/laminas-eventmanager",
             "version": "3.14.0",
@@ -76,59 +125,58 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.23.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b"
+                "reference": "b87a792d232c006eec9787230f611c74cc57b8b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a8640182b892b99767d54404d19c5c3b3699f79b",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b87a792d232c006eec9787230f611c74cc57b8b6",
+                "reference": "b87a792d232c006eec9787230f611c74cc57b8b6",
                 "shasum": ""
             },
             "require": {
+                "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0",
                 "laminas/laminas-stdlib": "^3.19",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1 || ^2.0"
             },
             "conflict": {
-                "ext-psr": "*",
                 "laminas/laminas-code": "<4.10.0",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
+                "zendframework/zend-code": "<3.3.1"
             },
             "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
+                "psr/container-implementation": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "boesing/psalm-plugin-stringf": "^1.4",
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "friendsofphp/proxy-manager-lts": "^1.0.18",
-                "laminas/laminas-code": "^4.14.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-cli": "^1.8",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "laminas/laminas-container-config-test": "^1.0",
+                "lctrs/psalm-psr-container-plugin": "^1.9",
                 "mikey179/vfsstream": "^1.6.12",
                 "phpbench/phpbench": "^1.3.1",
                 "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.18.4",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "symfony/console": "^6.0",
                 "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
-                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
+                "laminas/laminas-cli": "To consume CLI commands provided by this component"
             },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ServiceManager",
+                    "config-provider": "Laminas\\ServiceManager\\ConfigProvider"
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -150,11 +198,9 @@
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.3.0"
             },
             "funding": [
                 {
@@ -162,7 +208,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-28T21:32:16+00:00"
+            "time": "2024-11-05T00:35:06+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -224,23 +270,84 @@
             "time": "2024-10-29T13:46:07+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.1.2",
+            "name": "nikic/php-parser",
+            "version": "v4.19.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
+            },
+            "time": "2024-09-29T15:01:53+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -267,60 +374,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         }
     ],
     "packages-dev": [
@@ -1106,6 +1162,166 @@
             "time": "2024-08-06T10:04:20+00:00"
         },
         {
+            "name": "laminas/laminas-cache",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cache.git",
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/557c34091fdee1791bc16ddc06af583f94caa2dd",
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^3.4",
+                "laminas/laminas-servicemanager": "^4.1",
+                "laminas/laminas-stdlib": "^3.20",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/clock": "^1.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "webmozart/assert": "^1.11"
+            },
+            "conflict": {
+                "laminas/laminas-serializer": "<3.0",
+                "symfony/console": "<5.1"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-config-aggregator": "^1.17",
+                "laminas/laminas-serializer": "^3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
+                "laminas/laminas-cache-storage-adapter-blackhole": "Blackhole/Void implementation",
+                "laminas/laminas-cache-storage-adapter-ext-mongodb": "MongoDB implementation",
+                "laminas/laminas-cache-storage-adapter-filesystem": "Filesystem implementation",
+                "laminas/laminas-cache-storage-adapter-memcached": "Memcached implementation",
+                "laminas/laminas-cache-storage-adapter-memory": "Memory implementation",
+                "laminas/laminas-cache-storage-adapter-redis": "Redis implementation",
+                "laminas/laminas-cache-storage-adapter-session": "Session implementation",
+                "laminas/laminas-cli": "The laminas-cli binary can be used to consume commands provided by this component",
+                "laminas/laminas-serializer": "Laminas\\Serializer component"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Cache",
+                    "config-provider": "Laminas\\Cache\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Caching implementation with a variety of storage options, as well as codified caching strategies for callbacks, classes, and output",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "cache",
+                "laminas",
+                "psr-16",
+                "psr-6"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-cache/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-cache/issues",
+                "rss": "https://github.com/laminas/laminas-cache/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-01-21T12:32:41+00:00"
+        },
+        {
+            "name": "laminas/laminas-cache-storage-adapter-memory",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/10f0d64c0b3e381a8baaca108803111aa7b110db",
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-cache": "^4.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "laminas/laminas-cache-storage-implementation": "2.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cache-storage-adapter-benchmark": "^2.0",
+                "laminas/laminas-cache-storage-adapter-test": "^4.1",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "lcobucci/clock": "^3.0",
+                "lctrs/psalm-psr-container-plugin": "^1.10",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.24"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\Cache\\Storage\\Adapter\\Memory",
+                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Memory\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cache\\Storage\\Adapter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas cache adapter for memory",
+            "keywords": [
+                "cache",
+                "laminas"
+            ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memory/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memory/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memory/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-memory"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-11-27T08:14:09+00:00"
+        },
+        {
             "name": "laminas/laminas-coding-standard",
             "version": "3.0.1",
             "source": {
@@ -1342,6 +1558,59 @@
             "time": "2024-12-05T14:43:32+00:00"
         },
         {
+            "name": "laminas/laminas-translator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-21T15:33:01+00:00"
+        },
+        {
             "name": "laminas/laminas-uri",
             "version": "2.13.0",
             "source": {
@@ -1401,49 +1670,43 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.64.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "771e504760448ac7af660710237ceb93be602e08"
+                "reference": "ab6f4564360edba978d6b5082dc99cea2bd9bdef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
-                "reference": "771e504760448ac7af660710237ceb93be602e08",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ab6f4564360edba978d6b5082dc99cea2bd9bdef",
+                "reference": "ab6f4564360edba978d6b5082dc99cea2bd9bdef",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-servicemanager": "^3.21.0",
+                "ext-ctype": "*",
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^4.1.0",
                 "laminas/laminas-stdlib": "^3.19",
+                "laminas/laminas-translator": "^1.0",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/http-message": "^1.0.1 || ^2.0.0"
-            },
-            "conflict": {
-                "zendframework/zend-validator": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5",
-                "laminas/laminas-db": "^2.20",
-                "laminas/laminas-filter": "^2.35.2",
-                "laminas/laminas-i18n": "^2.26.0",
-                "laminas/laminas-session": "^2.20",
-                "laminas/laminas-uri": "^2.11.0",
-                "phpunit/phpunit": "^10.5.20",
-                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/container": "^1.1 || ^2.0",
                 "psr/http-client": "^1.0.3",
                 "psr/http-factory": "^1.1.0",
-                "vimeo/psalm": "^5.24.0"
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-diactoros": "^3.5.0",
+                "maglnet/composer-require-checker": "^4.7.1",
+                "phpunit/phpunit": "^10.5.37",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
-                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
-                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-                "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
-                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
-                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+                "laminas/laminas-i18n-resources": "Translations of validator messages"
             },
             "type": "library",
             "extra": {
@@ -1481,7 +1744,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-26T21:29:17+00:00"
+            "time": "2024-11-29T09:36:29+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1593,62 +1856,6 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
             },
             "time": "2024-09-08T10:13:13+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.19.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
-            },
-            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2473,6 +2680,210 @@
             "time": "2024-03-15T10:43:15+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "2.0",
             "source": {
@@ -2574,6 +2985,57 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -463,14 +463,6 @@
     </MixedAssignment>
   </file>
   <file src="src/Service/SessionConfigFactory.php">
-    <MixedArgument>
-      <code><![CDATA[$config]]></code>
-      <code><![CDATA[$config['config_class']]]></code>
-      <code><![CDATA[$config['config_class']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$config]]></code>
-    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -463,6 +463,14 @@
     </MixedAssignment>
   </file>
   <file src="src/Service/SessionConfigFactory.php">
+    <MixedArgument>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$config['config_class']]]></code>
+      <code><![CDATA[$config['config_class']]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$config]]></code>
+    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -450,13 +450,6 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Service/ContainerAbstractServiceFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[ContainerAbstractServiceFactory]]></code>
-    </DeprecatedInterface>
-    <MissingConstructor>
-      <code><![CDATA[$config]]></code>
-      <code><![CDATA[$sessionManager]]></code>
-    </MissingConstructor>
     <MixedArgument>
       <code><![CDATA[$config]]></code>
     </MixedArgument>
@@ -466,42 +459,23 @@
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$config]]></code>
-      <code><![CDATA[$this->sessionManager]]></code>
+      <code><![CDATA[$sessionManager]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[null|ManagerInterface]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->sessionManager]]></code>
-      <code><![CDATA[$this->sessionManager]]></code>
-    </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->sessionManager !== null]]></code>
-      <code><![CDATA[null !== $this->config]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Service/SessionConfigFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[SessionConfigFactory]]></code>
-    </DeprecatedInterface>
+    <MixedArgument>
+      <code><![CDATA[$config]]></code>
+      <code><![CDATA[$config['config_class']]]></code>
+      <code><![CDATA[$config['config_class']]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$config]]></code>
+    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Service/SessionManagerFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[SessionManagerFactory]]></code>
-    </DeprecatedInterface>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$manager]]></code>
-    </LessSpecificReturnStatement>
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$configService]]></code>
@@ -510,17 +484,8 @@
       <code><![CDATA[$storage]]></code>
       <code><![CDATA[$validators]]></code>
     </MixedAssignment>
-    <MoreSpecificReturnType>
-      <code><![CDATA[SessionManager]]></code>
-    </MoreSpecificReturnType>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Service/StorageFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[StorageFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$type]]></code>
@@ -530,9 +495,6 @@
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$type]]></code>
     </MixedAssignment>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/SessionManager.php">
     <DocblockTypeContradiction>
@@ -843,6 +805,11 @@
     <UndefinedDocblockClass>
       <code><![CDATA[CallbackHandler]]></code>
     </UndefinedDocblockClass>
+  </file>
+  <file src="src/Validator/Csrf.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$options]]></code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Validator/HttpUserAgent.php">
     <PossiblyNullPropertyAssignmentValue>
@@ -1213,52 +1180,17 @@
     <MissingReturnType>
       <code><![CDATA[testServiceNotCreatedWhenInvalidSamesiteConfig]]></code>
     </MissingReturnType>
-    <MixedAssignment>
-      <code><![CDATA[$config]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[getName]]></code>
-    </MixedMethodCall>
   </file>
   <file src="test/Service/SessionManagerFactoryTest.php">
-    <MixedArgument>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$manager]]></code>
-    </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$listener[0]]]></code>
       <code><![CDATA[$validatorData[Validator\HttpUserAgent::class]]]></code>
       <code><![CDATA[$validatorData[Validator\RemoteAddr::class]]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$chain]]></code>
       <code><![CDATA[$listener]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
       <code><![CDATA[$validatorData]]></code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[getConfig]]></code>
-      <code><![CDATA[getSaveHandler]]></code>
-      <code><![CDATA[getStorage]]></code>
-      <code><![CDATA[getStorage]]></code>
-      <code><![CDATA[getValidatorChain]]></code>
-      <code><![CDATA[getValidatorChain]]></code>
-      <code><![CDATA[start]]></code>
-      <code><![CDATA[start]]></code>
-      <code><![CDATA[start]]></code>
-    </MixedMethodCall>
     <UnusedVariable>
       <code><![CDATA[$manager]]></code>
       <code><![CDATA[$manager]]></code>
@@ -1269,14 +1201,6 @@
       <code><![CDATA[$config['session_storage']['options']]]></code>
       <code><![CDATA[$config['session_storage']['options']['input']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$storage]]></code>
-      <code><![CDATA[$storage]]></code>
-      <code><![CDATA[$test]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[toArray]]></code>
-    </MixedMethodCall>
     <UnusedVariable>
       <code><![CDATA[$storage]]></code>
     </UnusedVariable>
@@ -1428,9 +1352,6 @@
       <code><![CDATA[void]]></code>
       <code><![CDATA[void]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[ArrayStorage::class]]></code>
-    </InvalidPropertyAssignmentValue>
     <InvalidReturnType>
       <code><![CDATA[forgetMe]]></code>
       <code><![CDATA[getId]]></code>
@@ -1452,10 +1373,6 @@
     <PropertyNotSetInConstructor>
       <code><![CDATA[TestManager]]></code>
     </PropertyNotSetInConstructor>
-    <UndefinedDocblockClass>
-      <code><![CDATA[class-string<StorageInterface>]]></code>
-      <code><![CDATA[protected $storageDefaultClass = ArrayStorage::class;]]></code>
-    </UndefinedDocblockClass>
   </file>
   <file src="test/TestAsset/TestSaveHandler.php">
     <ImplementedParamTypeMismatch>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -798,11 +798,6 @@
       <code><![CDATA[CallbackHandler]]></code>
     </UndefinedDocblockClass>
   </file>
-  <file src="src/Validator/Csrf.php">
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
-    </MixedArgumentTypeCoercion>
-  </file>
   <file src="src/Validator/HttpUserAgent.php">
     <PossiblyNullPropertyAssignmentValue>
       <code><![CDATA[$data]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -278,9 +278,6 @@
       <code><![CDATA[null|string]]></code>
       <code><![CDATA[string|null]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument>
-      <code><![CDATA[HostnameValidator::ALLOW_ALL]]></code>
-    </InvalidArgument>
     <InvalidReturnType>
       <code><![CDATA[mixed]]></code>
     </InvalidReturnType>
@@ -1396,14 +1393,6 @@
     <MixedAssignment>
       <code><![CDATA[$result]]></code>
     </MixedAssignment>
-  </file>
-  <file src="test/Validator/CsrfTest.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[$container->hash]]></code>
-    </DocblockTypeContradiction>
-    <TypeDoesNotContainType>
-      <code><![CDATA[assertIsString]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="test/Validator/IdTest.php">
     <PossiblyUnusedMethod>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     errorBaseline="psalm-baseline.xml"
     findUnusedBaselineEntry="true"
     findUnusedCode="true"
+    findUnusedPsalmSuppress="true"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Config/StandardConfig.php
+++ b/src/Config/StandardConfig.php
@@ -492,7 +492,7 @@ class StandardConfig implements ConfigInterface, SameSiteCookieCapableInterface
             throw new Exception\InvalidArgumentException('Invalid cookie domain: must be a string');
         }
 
-        $validator = new HostnameValidator(HostnameValidator::ALLOW_ALL);
+        $validator = new HostnameValidator(['allow' => HostnameValidator::ALLOW_ALL]);
 
         if (! empty($cookieDomain) && ! $validator->isValid($cookieDomain)) {
             throw new Exception\InvalidArgumentException(

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -36,19 +36,19 @@ use function strtolower;
  * $container = $services->get('MySessionContainer');
  * </code>
  */
-class ContainerAbstractServiceFactory implements AbstractFactoryInterface
+final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 {
     /**
      * Cached container configuration
      */
-    protected array $config = [];
+    private ?array $config = null;
 
     /**
      * Configuration key in which session containers live
      */
-    protected string $configKey = 'session_containers';
+    private string $configKey = 'session_containers';
 
-    protected ?ManagerInterface $sessionManager = null;
+    private ?ManagerInterface $sessionManager = null;
 
     /**
      * Can we create an instance of the given service?
@@ -78,16 +78,18 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
      */
     protected function getConfig(ContainerInterface $container): array
     {
-        if (! empty($this->config)) {
+        if ($this->config !== null) {
             return $this->config;
         }
 
         if (! $container->has('config')) {
+            $this->config = [];
             return $this->config;
         }
 
         $config = $container->get('config');
         if (! isset($config[$this->configKey]) || ! is_array($config[$this->configKey])) {
+            $this->config = [];
             return $this->config;
         }
 

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -60,8 +60,7 @@ final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
             return false;
         }
 
-        $containerName = $this->normalizeContainerName($requestedName);
-        return array_key_exists($containerName, $config);
+        return array_key_exists(strtolower($requestedName), $config);
     }
 
     /**
@@ -76,7 +75,7 @@ final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     /**
      * Retrieve config from service locator, and cache for later
      */
-    protected function getConfig(ContainerInterface $container): array
+    private function getConfig(ContainerInterface $container): array
     {
         if ($this->config !== null) {
             return $this->config;
@@ -104,7 +103,7 @@ final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     /**
      * Retrieve the session manager instance, if any
      */
-    protected function getSessionManager(ContainerInterface $container): ?ManagerInterface
+    private function getSessionManager(ContainerInterface $container): ?ManagerInterface
     {
         if ($this->sessionManager !== null) {
             return $this->sessionManager;
@@ -119,13 +118,5 @@ final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         return $this->sessionManager;
-    }
-
-    /**
-     * Normalize the container name in order to perform a lookup
-     */
-    protected function normalizeContainerName(string $name): string
-    {
-        return strtolower($name);
     }
 }

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -4,11 +4,10 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\AbstractFactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\Session\Container;
 use Laminas\Session\ManagerInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_change_key_case;
 use function array_flip;
@@ -41,28 +40,20 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 {
     /**
      * Cached container configuration
-     *
-     * @var array
      */
-    protected $config;
+    protected array $config = [];
 
     /**
      * Configuration key in which session containers live
-     *
-     * @var string
      */
-    protected $configKey = 'session_containers';
+    protected string $configKey = 'session_containers';
 
-    /** @var ManagerInterface */
-    protected $sessionManager;
+    protected ?ManagerInterface $sessionManager = null;
 
     /**
-     * Can we create an instance of the given service? (v3 usage).
-     *
-     * @param string $requestedName
-     * @return bool
+     * Can we create an instance of the given service?
      */
-    public function canCreate(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, string $requestedName): bool
     {
         $config = $this->getConfig($container);
         if ($config === []) {
@@ -74,62 +65,29 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @deprecated This method will be removed in version 3.0
-     * Can we create an instance of the given service? (v2 usage)
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @return bool
+     * Create and return a named container.
      */
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this->canCreate($container, $requestedName);
-    }
-
-    /**
-     * Create and return a named container (v3 usage).
-     *
-     * @param string $requestedName
-     * @return Container
-     */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): Container
     {
         $manager = $this->getSessionManager($container);
         return new Container($requestedName, $manager);
     }
 
     /**
-     * @deprecated This method will be removed in version 3.0
-     * Create and return a named container (v2 usage).
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @return Container
-     */
-    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this($container, $requestedName);
-    }
-
-    /**
      * Retrieve config from service locator, and cache for later
-     *
-     * @return array
      */
-    protected function getConfig(ContainerInterface $container)
+    protected function getConfig(ContainerInterface $container): array
     {
-        if (null !== $this->config) {
+        if (! empty($this->config)) {
             return $this->config;
         }
 
         if (! $container->has('config')) {
-            $this->config = [];
             return $this->config;
         }
 
         $config = $container->get('config');
         if (! isset($config[$this->configKey]) || ! is_array($config[$this->configKey])) {
-            $this->config = [];
             return $this->config;
         }
 
@@ -143,17 +101,19 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Retrieve the session manager instance, if any
-     *
-     * @return null|ManagerInterface
      */
-    protected function getSessionManager(ContainerInterface $container)
+    protected function getSessionManager(ContainerInterface $container): ?ManagerInterface
     {
         if ($this->sessionManager !== null) {
             return $this->sessionManager;
         }
 
         if ($container->has(ManagerInterface::class)) {
-            $this->sessionManager = $container->get(ManagerInterface::class);
+            $sessionManager = $container->get(ManagerInterface::class);
+
+            if ($sessionManager instanceof ManagerInterface) {
+                $this->sessionManager = $sessionManager;
+            }
         }
 
         return $this->sessionManager;
@@ -161,11 +121,8 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Normalize the container name in order to perform a lookup
-     *
-     * @param  string $name
-     * @return string
      */
-    protected function normalizeContainerName($name)
+    protected function normalizeContainerName(string $name): string
     {
         return strtolower($name);
     }

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -9,6 +9,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SameSiteCookieCapableInterface;
 use Laminas\Session\Config\SessionConfig;
+use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -4,13 +4,14 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SameSiteCookieCapableInterface;
 use Laminas\Session\Config\SessionConfig;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
 
 use function class_exists;
@@ -21,21 +22,22 @@ use function sprintf;
 class SessionConfigFactory implements FactoryInterface
 {
     /**
-     * Create session configuration object (v3 usage).
+     * Create session configuration object.
      *
      * Uses "session_config" section of configuration to seed a ConfigInterface
      * instance. By default, Laminas\Session\Config\SessionConfig will be used, but
      * you may also specify a specific implementation variant using the
      * "config_class" subkey.
      *
-     * @param string $requestedName
-     * @param null|array $options
-     * @return ConfigInterface
      * @throws ServiceNotCreatedException If session_config is missing, or an
      *     invalid config_class is used.
+     * @throws NotFoundExceptionInterface|ContainerExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): ConfigInterface {
         $config = $container->get('config');
         if (! isset($config['session_config']) || ! is_array($config['session_config'])) {
             throw new ServiceNotCreatedException(
@@ -114,21 +116,5 @@ class SessionConfigFactory implements FactoryInterface
         $sessionConfig->setOptions($config);
 
         return $sessionConfig;
-    }
-
-    /**
-     * @deprecated This method will be removed in version 3.0
-     * Create and return a config instance (v2 usage).
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return ConfigInterface
-     */
-    public function createService(
-        ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = ConfigInterface::class
-    ) {
-        return $this($services, $requestedName);
     }
 }

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -13,14 +13,13 @@ use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use Laminas\Session\SaveHandler\SaveHandlerInterface;
 
 use function class_exists;
 use function get_debug_type;
 use function is_array;
 use function sprintf;
 
-class SessionConfigFactory implements FactoryInterface
+final class SessionConfigFactory implements FactoryInterface
 {
     /**
      * Create session configuration object.

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -4,16 +4,15 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Container;
 use Laminas\Session\ManagerInterface;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\SessionManager;
 use Laminas\Session\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_merge;
 use function class_exists;
@@ -34,7 +33,7 @@ class SessionManagerFactory implements FactoryInterface
     ];
 
     /**
-     * Create session manager object (v3 usage).
+     * Create session manager object.
      *
      * Will consume any combination (or zero) of the following services, when
      * present, to construct the SessionManager instance:
@@ -58,12 +57,12 @@ class SessionManagerFactory implements FactoryInterface
      *   as the default manager for Container instances. The default value for
      *   this is true; set it to false to disable.
      * - validators: ...
-     *
-     * @param string $requestedName
-     * @return SessionManager
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): ManagerInterface {
         $config        = null;
         $storage       = null;
         $saveHandler   = null;
@@ -125,7 +124,6 @@ class SessionManagerFactory implements FactoryInterface
                 $options = $managerConfig['options'];
             }
         }
-
         $managerClass = class_exists($requestedName) ? $requestedName : SessionManager::class;
         if (! is_subclass_of($managerClass, ManagerInterface::class)) {
             throw new ServiceNotCreatedException(sprintf(
@@ -147,21 +145,5 @@ class SessionManagerFactory implements FactoryInterface
         }
 
         return $manager;
-    }
-
-    /**
-     * @deprecated This method will be removed in version 3.0
-     * Create a SessionManager instance (v2 usage)
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return SessionManager
-     */
-    public function createService(
-        ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = SessionManager::class
-    ) {
-        return $this($services, $requestedName);
     }
 }

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -21,14 +21,12 @@ use function is_array;
 use function is_subclass_of;
 use function sprintf;
 
-class SessionManagerFactory implements FactoryInterface
+final class SessionManagerFactory implements FactoryInterface
 {
     /**
      * Default configuration for manager behavior
-     *
-     * @var array
      */
-    protected $defaultManagerConfig = [
+    private array $defaultManagerConfig = [
         'enable_default_container_manager' => true,
     ];
 

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -4,13 +4,14 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\Session\Exception\ExceptionInterface as SessionException;
 use Laminas\Session\Storage\Factory;
 use Laminas\Session\Storage\StorageInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 use function is_array;
 use function sprintf;
@@ -18,20 +19,20 @@ use function sprintf;
 class StorageFactory implements FactoryInterface
 {
     /**
-     * Create session storage object (v3 usage).
-     *
      * Uses "session_storage" section of configuration to seed a StorageInterface
      * instance. That array should contain the key "type", specifying the storage
      * type to use, and optionally "options", containing any options to be used in
      * creating the StorageInterface instance.
      *
-     * @param string $requestedName
-     * @return StorageInterface
      * @throws ServiceNotCreatedException If session_storage is missing, or the
      *         factory cannot create the storage instance.
+     * @throws NotFoundExceptionInterface|ContainerExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): StorageInterface {
         $config = $container->get('config');
         if (! isset($config['session_storage']) || ! is_array($config['session_storage'])) {
             throw new ServiceNotCreatedException(
@@ -58,21 +59,5 @@ class StorageFactory implements FactoryInterface
         }
 
         return $storage;
-    }
-
-    /**
-     * @deprecated This method will be removed in version 3.0
-     * Create and return a storage instance (v2 usage).
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return StorageInterface
-     */
-    public function createService(
-        ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = StorageInterface::class
-    ) {
-        return $this($services, $requestedName);
     }
 }

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -16,7 +16,7 @@ use Psr\Container\NotFoundExceptionInterface;
 use function is_array;
 use function sprintf;
 
-class StorageFactory implements FactoryInterface
+final class StorageFactory implements FactoryInterface
 {
     /**
      * Uses "session_storage" section of configuration to seed a StorageInterface

--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Session\Validator;
 
 use Laminas\Session\Container;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 
 use function assert;
@@ -18,12 +19,25 @@ use function sprintf;
 use function str_replace;
 use function strtr;
 
+/**
+ * @psalm-type OptionsArgument = array{
+ * hash?: non-empty-string,
+ * name?: non-empty-string,
+ * salt?: non-empty-string,
+ * session?: Container,
+ * timeout?: int,
+ * messages?: array<string, string>,
+ * translator?: TranslatorInterface|null,
+ * translatorTextDomain?: string|null,
+ * translatorEnabled?: bool,
+ * valueObscured?: bool,
+ * ...<string, mixed>
+ * }
+ */
 final class Csrf extends AbstractValidator
 {
     /**
      * Error codes
-     *
-     * @var string
      */
     public const NOT_SAME = 'notSame';
 
@@ -62,6 +76,7 @@ final class Csrf extends AbstractValidator
      */
     private ?int $timeout;
 
+    /** @param OptionsArgument $options  */
     public function __construct(array $options = [])
     {
         parent::__construct($options);

--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -53,7 +53,7 @@ final class Csrf extends AbstractValidator
     /**
      * Actual hash used.
      */
-    private ?string $hash;
+    private string $hash;
 
     /**
      * Name of CSRF element (used to create non-colliding hashes)
@@ -69,7 +69,7 @@ final class Csrf extends AbstractValidator
      */
     private string $salt;
 
-    private ?Container $session;
+    private Container $session;
 
     /**
      * TTL for CSRF token
@@ -93,11 +93,16 @@ final class Csrf extends AbstractValidator
         assert($session instanceof Container || $session === null);
         assert(is_int($timeout) || $timeout === null);
 
-        $this->hash    = $hash;
         $this->name    = $name;
         $this->salt    = $salt;
-        $this->session = $session;
         $this->timeout = $timeout;
+        $this->session = $this->getSessionContainer($session);
+
+        if (null === $hash) {
+            $this->generateHash();
+        } else {
+            $this->hash = $hash;
+        }
     }
 
     /**
@@ -127,85 +132,12 @@ final class Csrf extends AbstractValidator
         return true;
     }
 
-    /**
-     * Set CSRF name
-     *
-     * @param non-empty-string $name
-     */
-    public function setName(string $name): void
+    private function getSessionContainer(?Container $container): Container
     {
-        $this->name = $name;
-    }
-
-    /**
-     * Get CSRF name
-     *
-     * @return non-empty-string
-     */
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
-     * Set session container
-     */
-    public function setSession(Container $session): void
-    {
-        $this->session = $session;
-        if ($this->hash !== null) {
-            $this->initCsrfToken();
+        if (null === $container) {
+            $container = new Container($this->getSessionName());
         }
-    }
-
-    /**
-     * Get session container
-     *
-     * Instantiate session container if none currently exists
-     */
-    public function getSession(): Container
-    {
-        if (null === $this->session) {
-            $this->session = new Container($this->getSessionName());
-        }
-        return $this->session;
-    }
-
-    /**
-     * Salt for CSRF token
-     *
-     * @param non-empty-string $salt
-     */
-    public function setSalt(string $salt): void
-    {
-        $this->salt = $salt;
-    }
-
-    /**
-     * Retrieve salt for CSRF token
-     *
-     * @return non-empty-string
-     */
-    public function getSalt(): string
-    {
-        return $this->salt;
-    }
-
-    /**
-     * Retrieve CSRF token
-     *
-     * If no CSRF token currently exists, or should be regenerated,
-     * generates one.
-     */
-    public function getHash(bool $regenerate = false): string
-    {
-        if ((null === $this->hash) || $regenerate) {
-            $this->generateHash();
-        }
-
-        assert($this->hash !== null);
-
-        return $this->hash;
+        return $container;
     }
 
     /**
@@ -216,24 +148,8 @@ final class Csrf extends AbstractValidator
     public function getSessionName(): string
     {
         return str_replace('\\', '_', self::class) . '_'
-            . $this->getSalt() . '_'
-            . strtr($this->getName(), ['[' => '_', ']' => '']);
-    }
-
-    /**
-     * Set timeout for CSRF session token
-     */
-    public function setTimeout(int|null $ttl): void
-    {
-        $this->timeout = $ttl;
-    }
-
-    /**
-     * Get CSRF session token timeout
-     */
-    public function getTimeout(): int|null
-    {
-        return $this->timeout;
+            . $this->salt . '_'
+            . strtr($this->name, ['[' => '_', ']' => '']);
     }
 
     /**
@@ -241,13 +157,13 @@ final class Csrf extends AbstractValidator
      */
     private function initCsrfToken(): void
     {
-        $session = $this->getSession();
-        $timeout = $this->getTimeout();
+        $session = $this->session;
+        $timeout = $this->timeout;
         if (null !== $timeout) {
             $session->setExpirationSeconds($timeout);
         }
 
-        $hash    = $this->getHash();
+        $hash    = $this->hash;
         $token   = $this->getTokenFromHash($hash);
         $tokenId = $this->getTokenIdFromHash($hash);
         assert(is_string($tokenId));
@@ -257,7 +173,6 @@ final class Csrf extends AbstractValidator
         $tokenList[$tokenId] = $token;
 
         $session->tokenList = $tokenList;
-        $session->hash      = $hash; // @todo remove this, left for BC
     }
 
     /**
@@ -267,8 +182,7 @@ final class Csrf extends AbstractValidator
      */
     private function generateHash(): void
     {
-        $token = md5($this->getSalt() . random_bytes(32) . $this->getName());
-
+        $token      = md5($this->salt . random_bytes(32) . $this->name);
         $this->hash = $this->formatHash($token, $this->generateTokenId());
 
         $this->setValue($this->hash);
@@ -287,16 +201,7 @@ final class Csrf extends AbstractValidator
      */
     private function getValidationToken(string|null $tokenId = null): string|null
     {
-        $session = $this->getSession();
-
-        /**
-         * if no tokenId is passed we revert to the old behaviour
-         *
-         * @todo remove, here for BC
-         */
-        if ($tokenId === null && isset($session->hash) && is_string($session->hash)) {
-            return $session->hash;
-        }
+        $session = $this->session;
 
         if ($tokenId !== null && isset($session->tokenList[$tokenId]) && is_string($session->tokenList[$tokenId])) {
             return $this->formatHash($session->tokenList[$tokenId], $tokenId);

--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -25,7 +25,7 @@ use function strtr;
  * name?: non-empty-string,
  * salt?: non-empty-string,
  * session?: Container,
- * timeout?: int,
+ * timeout?: positive-int,
  * messages?: array<string, string>,
  * translator?: TranslatorInterface|null,
  * translatorTextDomain?: string|null,
@@ -73,8 +73,10 @@ final class Csrf extends AbstractValidator
 
     /**
      * TTL for CSRF token
+     *
+     * @var positive-int
      */
-    private ?int $timeout;
+    private int $timeout;
 
     /** @param OptionsArgument $options  */
     public function __construct(array $options = [])
@@ -91,7 +93,7 @@ final class Csrf extends AbstractValidator
         assert(is_string($name) && $name !== '');
         assert(is_string($salt) && $salt !== '');
         assert($session instanceof Container || $session === null);
-        assert(is_int($timeout) || $timeout === null);
+        assert(is_int($timeout) && $timeout > 0);
 
         $this->name    = $name;
         $this->salt    = $salt;
@@ -158,10 +160,7 @@ final class Csrf extends AbstractValidator
     private function initCsrfToken(): void
     {
         $session = $this->session;
-        $timeout = $this->timeout;
-        if (null !== $timeout) {
-            $session->setExpirationSeconds($timeout);
-        }
+        $session->setExpirationSeconds($this->timeout);
 
         $hash    = $this->hash;
         $token   = $this->getTokenFromHash($hash);

--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -10,6 +10,7 @@ use Laminas\Validator\AbstractValidator;
 use function assert;
 use function explode;
 use function is_array;
+use function is_int;
 use function is_string;
 use function md5;
 use function random_bytes;
@@ -17,20 +18,12 @@ use function sprintf;
 use function str_replace;
 use function strtr;
 
-/**
- * @psalm-type OptionsArgument = array{
- *     name?: non-empty-string,
- *     salt?: non-empty-string,
- *     session?: Container,
- *     timeout?: ?int,
- * }
- */
 final class Csrf extends AbstractValidator
 {
     /**
      * Error codes
      *
-     * @const string
+     * @var string
      */
     public const NOT_SAME = 'notSame';
 
@@ -46,33 +39,50 @@ final class Csrf extends AbstractValidator
     /**
      * Actual hash used.
      */
-    private ?string $hash = null;
+    private ?string $hash;
 
     /**
      * Name of CSRF element (used to create non-colliding hashes)
      *
      * @var non-empty-string
      */
-    private string $name = 'csrf';
+    private string $name;
 
     /**
      * Salt for CSRF token
      *
      * @var non-empty-string
      */
-    private string $salt = 'salt';
+    private string $salt;
 
-    private ?Container $session = null;
+    private ?Container $session;
 
     /**
      * TTL for CSRF token
      */
-    private int|null $timeout = 300;
+    private ?int $timeout;
 
-    /** @param OptionsArgument $options */
     public function __construct(array $options = [])
     {
         parent::__construct($options);
+
+        $hash    = $options['hash'] ?? null;
+        $name    = $options['name'] ?? 'csrf';
+        $salt    = $options['salt'] ?? 'salt';
+        $session = $options['session'] ?? null;
+        $timeout = $options['timeout'] ?? 300;
+
+        assert(is_string($hash) || $hash === null);
+        assert(is_string($name) && $name !== '');
+        assert(is_string($salt) && $salt !== '');
+        assert($session instanceof Container || $session === null);
+        assert(is_int($timeout) || $timeout === null);
+
+        $this->hash    = $hash;
+        $this->name    = $name;
+        $this->salt    = $salt;
+        $this->session = $session;
+        $this->timeout = $timeout;
     }
 
     /**

--- a/test/Service/SessionManagerFactoryTest.php
+++ b/test/Service/SessionManagerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Session\Service;
 
-use Laminas\EventManager\EventManagerInterface;
+use Laminas\EventManager\EventManager;
 use Laminas\EventManager\Test\EventListenerIntrospectionTrait;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceManager;
@@ -119,8 +119,8 @@ class SessionManagerFactoryTest extends TestCase
 
         $chain = $manager->getValidatorChain();
 
-        self::assertInstanceOf(EventManagerInterface::class, $chain);
-        /** @psalm-suppress ArgumentTypeCoercion **/
+        self::assertInstanceOf(EventManager::class, $chain);
+
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
     }
@@ -209,8 +209,8 @@ class SessionManagerFactoryTest extends TestCase
 
         $chain = $manager->getValidatorChain();
 
-        self::assertInstanceOf(EventManagerInterface::class, $chain);
-        /** @psalm-suppress ArgumentTypeCoercion **/
+        self::assertInstanceOf(EventManager::class, $chain);
+
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
 

--- a/test/Service/SessionManagerFactoryTest.php
+++ b/test/Service/SessionManagerFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Session\Service;
 
+use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\Test\EventListenerIntrospectionTrait;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceManager;
@@ -114,7 +115,11 @@ class SessionManagerFactoryTest extends TestCase
 
         $manager->start();
 
+        self::assertInstanceOf(ManagerInterface::class, $manager);
+
         $chain = $manager->getValidatorChain();
+
+        self::assertInstanceOf(EventManagerInterface::class, $chain);
         /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
@@ -193,6 +198,9 @@ class SessionManagerFactoryTest extends TestCase
         );
 
         $manager = $this->services->get(ManagerInterface::class);
+
+        self::assertInstanceOf(ManagerInterface::class, $manager);
+
         try {
             $manager->start();
         } catch (RuntimeException) {
@@ -200,6 +208,8 @@ class SessionManagerFactoryTest extends TestCase
         }
 
         $chain = $manager->getValidatorChain();
+
+        self::assertInstanceOf(EventManagerInterface::class, $chain);
         /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);

--- a/test/Service/SessionManagerFactoryTest.php
+++ b/test/Service/SessionManagerFactoryTest.php
@@ -114,7 +114,8 @@ class SessionManagerFactoryTest extends TestCase
 
         $manager->start();
 
-        $chain     = $manager->getValidatorChain();
+        $chain = $manager->getValidatorChain();
+        /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
     }
@@ -198,7 +199,8 @@ class SessionManagerFactoryTest extends TestCase
             // Ignore exception, because we are not interested whether session validation passes in this test
         }
 
-        $chain     = $manager->getValidatorChain();
+        $chain = $manager->getValidatorChain();
+        /** @psalm-suppress ArgumentTypeCoercion **/
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
 

--- a/test/TestAsset/TestManager.php
+++ b/test/TestAsset/TestManager.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Session\TestAsset;
 
 use Laminas\EventManager\EventManagerInterface;
-use Laminas\Sessin\Storage\StorageInterface;
 use Laminas\Session\AbstractManager;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\StandardConfig;
 use Laminas\Session\Storage\ArrayStorage;
+use Laminas\Session\Storage\StorageInterface;
 
 class TestManager extends AbstractManager
 {

--- a/test/Validator/CsrfTest.php
+++ b/test/Validator/CsrfTest.php
@@ -9,8 +9,10 @@ use Laminas\Session\Container;
 use Laminas\Session\SessionManager;
 use Laminas\Session\Storage\ArrayStorage;
 use Laminas\Session\Validator\Csrf;
+use LaminasTest\Session\ReflectionPropertyTrait;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use ReflectionObject;
 
 use function class_exists;
 use function md5;
@@ -21,7 +23,10 @@ use function uniqid;
 
 class CsrfTest extends TestCase
 {
+    use ReflectionPropertyTrait;
+
     private Csrf $validator;
+    private ReflectionObject $validatorReflection;
     private SessionManager $sessionManager;
 
     protected function setUp(): void
@@ -37,7 +42,14 @@ class CsrfTest extends TestCase
         $this->sessionManager = $sessionManager;
         Container::setDefaultManager($sessionManager);
 
-        $this->validator = new Csrf();
+        $this->validator           = new Csrf();
+        $this->validatorReflection = new ReflectionObject($this->validator);
+    }
+
+    private function getValidatorPropertyValue(string $property): mixed
+    {
+        $reflectionProperty = $this->validatorReflection->getProperty($property);
+        return $reflectionProperty->getValue($this->validator);
     }
 
     protected function tearDown(): void
@@ -54,118 +66,94 @@ class CsrfTest extends TestCase
 
     public function testSaltHasDefaultValueIfNotSet(): void
     {
-        self::assertSame('salt', $this->validator->getSalt());
-    }
+        $salt = $this->getValidatorPropertyValue('salt');
 
-    public function testSaltIsMutable(): void
-    {
-        $this->validator->setSalt('pepper');
-
-        self::assertSame('pepper', $this->validator->getSalt());
+        self::assertIsString($salt);
+        self::assertSame('salt', $salt);
     }
 
     public function testSessionContainerIsLazyLoadedIfNotSet(): void
     {
-        $container = $this->validator->getSession();
+        $container = $this->getValidatorPropertyValue('session');
 
         self::assertInstanceOf(Container::class, $container);
     }
 
-    public function testSessionContainerIsMutable(): void
-    {
-        $container = new Container('foo', $this->sessionManager);
-        $this->validator->setSession($container);
-
-        self::assertSame($container, $this->validator->getSession());
-    }
-
     public function testNameHasDefaultValue(): void
     {
-        self::assertSame('csrf', $this->validator->getName());
-    }
-
-    public function testNameIsMutable(): void
-    {
-        $this->validator->setName('foo');
-
-        self::assertSame('foo', $this->validator->getName());
+        self::assertSame('csrf', $this->getValidatorPropertyValue('name'));
     }
 
     public function testTimeoutHasDefaultValue(): void
     {
-        self::assertSame(300, $this->validator->getTimeout());
-    }
-
-    /**
-     * @return list<array{0: null|int, 1: null|int}>
-     */
-    public static function timeoutValuesDataProvider(): array
-    {
-        return [
-            //    timeout  expected
-            [600,     600],
-            [null,    null],
-            [0,     0],
-            [100,   100],
-        ];
-    }
-
-    /**
-     * @dataProvider timeoutValuesDataProvider
-     */
-    public function testTimeoutIsMutable(int|null $timeout, ?int $expected): void
-    {
-        $this->validator->setTimeout($timeout);
-
-        self::assertSame($expected, $this->validator->getTimeout());
+        self::assertSame(300, $this->getValidatorPropertyValue('timeout'));
     }
 
     public function testAllOptionsMayBeSetViaConstructor(): void
     {
         $container = new Container('foo', $this->sessionManager);
         $options   = [
-            'name'    => 'hash',
+            'hash'    => 'bar',
+            'name'    => 'baz',
             'salt'    => 'salty',
             'session' => $container,
             'timeout' => 600,
         ];
         $validator = new Csrf($options);
 
-        self::assertSame('hash', $validator->getName());
-        self::assertSame('salty', $validator->getSalt());
-        self::assertSame($container, $validator->getSession());
-        self::assertSame(600, $validator->getTimeout());
+        self::assertSame('bar', $this->getReflectionProperty($validator, 'hash'));
+        self::assertSame('baz', $this->getReflectionProperty($validator, 'name'));
+        self::assertSame('salty', $this->getReflectionProperty($validator, 'salt'));
+        self::assertSame($container, $this->getReflectionProperty($validator, 'session'));
+        self::assertSame(600, $this->getReflectionProperty($validator, 'timeout'));
     }
 
     public function testHashIsGeneratedOnFirstRetrieval(): void
     {
-        $hash = $this->validator->getHash();
+        $hash = $this->getValidatorPropertyValue('hash');
 
         self::assertNotEmpty($hash);
 
-        $test = $this->validator->getHash();
+        $test = $this->getValidatorPropertyValue('hash');
 
         self::assertSame($hash, $test);
     }
 
     public function testSessionNameIsDerivedFromClassSaltAndName(): void
     {
-        $class    = $this->validator::class;
-        $class    = str_replace('\\', '_', $class);
-        $expected = sprintf('%s_%s_%s', $class, $this->validator->getSalt(), $this->validator->getName());
+        $class = $this->validator::class;
+        $class = str_replace('\\', '_', $class);
+        $salt  = $this->getValidatorPropertyValue('salt');
+        $name  = $this->getValidatorPropertyValue('name');
+
+        self::assertIsString($salt);
+        self::assertIsString($name);
+
+        $expected = sprintf('%s_%s_%s', $class, $salt, $name);
 
         self::assertSame($expected, $this->validator->getSessionName());
     }
 
     public function testSessionNameRemainsValidForElementBelongingToFieldset(): void
     {
-        $this->validator->setName('fieldset[csrf]');
-        $class    = $this->validator::class;
-        $class    = str_replace('\\', '_', $class);
-        $name     = strtr($this->validator->getName(), ['[' => '_', ']' => '']);
-        $expected = sprintf('%s_%s_%s', $class, $this->validator->getSalt(), $name);
+        $container = new Container('foo', $this->sessionManager);
+        $options   = [
+            'name'    => 'fieldset[csrf]',
+            'session' => $container,
+        ];
+        $validator = new Csrf($options);
+        $salt      = $this->getReflectionProperty($validator, 'salt');
+        $name      = $this->getReflectionProperty($validator, 'name');
 
-        self::assertSame($expected, $this->validator->getSessionName());
+        self::assertIsString($salt);
+        self::assertIsString($name);
+
+        $class    = $validator::class;
+        $class    = str_replace('\\', '_', $class);
+        $name     = strtr($name, ['[' => '_', ']' => '']);
+        $expected = sprintf('%s_%s_%s', $class, $salt, $name);
+
+        self::assertSame($expected, $validator->getSessionName());
     }
 
     public function testIsValidReturnsFalseWhenValueDoesNotMatchHash(): void
@@ -184,31 +172,31 @@ class CsrfTest extends TestCase
 
     public function testIsValidReturnsTrueWhenValueMatchesHash(): void
     {
-        $hash = $this->validator->getHash();
-
+        $hash = $this->getValidatorPropertyValue('hash');
+        self::assertIsString($hash);
         self::assertTrue($this->validator->isValid($hash));
     }
 
     public function testSessionContainerContainsHashAfterHashHasBeenGenerated(): void
     {
-        $container = $this->validator->getSession();
+        $container = $this->getValidatorPropertyValue('session');
+        self::assertInstanceOf(Container::class, $container);
         self::assertNull($container->hash);
 
-        $hash = $this->validator->getHash();
-        $test = $container->hash ?? null; // Doing this, as expiration hops are 1; have to grab on first access
+        $method       = new ReflectionMethod($this->validator::class, 'getTokenIdFromHash');
+        $formatMethod = new ReflectionMethod($this->validator::class, 'formatHash');
 
-        self::assertIsString($test);
-        self::assertSame($hash, $test);
-    }
+        $hash = $this->getValidatorPropertyValue('hash');
+        self::assertIsString($hash);
+        $tokenId = $method->invoke($this->validator, $hash);
+        self::assertIsString($tokenId);
+        $token = $container->tokenList[$tokenId] ?? '';
+        self::assertIsString($token);
 
-    public function testSettingNewSessionContainerSetsHashInNewContainer(): void
-    {
-        $hash      = $this->validator->getHash();
-        $container = new Container('foo', $this->sessionManager);
-        $this->validator->setSession($container);
-        $test = $container->hash; // Doing this, as expiration hops are 1; have to grab on first access
+        $testHash = $formatMethod->invoke($this->validator, $token, $tokenId);
 
-        self::assertSame($hash, $test);
+        self::assertIsString($testHash);
+        self::assertSame($hash, $testHash);
     }
 
     public function testMultipleValidatorsSharingContainerGenerateDifferentHashes(): void
@@ -216,13 +204,17 @@ class CsrfTest extends TestCase
         $validatorOne = new Csrf();
         $validatorTwo = new Csrf();
 
-        $containerOne = $validatorOne->getSession();
-        $containerTwo = $validatorOne->getSession();
+        $containerOne = $this->getReflectionProperty($validatorOne, 'session');
+        self::assertInstanceOf(Container::class, $containerOne);
+        $containerTwo = $this->getReflectionProperty($validatorOne, 'session');
+        self::assertInstanceOf(Container::class, $containerTwo);
 
         self::assertSame($containerOne, $containerTwo);
 
-        $hashOne = $validatorOne->getHash();
-        $hashTwo = $validatorTwo->getHash();
+        $hashOne = $this->getReflectionProperty($validatorOne, 'hash');
+        self::assertIsString($hashOne);
+        $hashTwo = $this->getReflectionProperty($validatorTwo, 'hash');
+        self::assertIsString($hashTwo);
 
         self::assertNotSame($hashOne, $hashTwo);
     }
@@ -232,8 +224,10 @@ class CsrfTest extends TestCase
         $validatorOne = new Csrf();
         $validatorTwo = new Csrf();
 
-        $hashOne = $validatorOne->getHash();
-        $hashTwo = $validatorTwo->getHash();
+        $hashOne = $this->getReflectionProperty($validatorOne, 'hash');
+        self::assertIsString($hashOne);
+        $hashTwo = $this->getReflectionProperty($validatorTwo, 'hash');
+        self::assertIsString($hashTwo);
 
         self::assertTrue($validatorOne->isValid($hashOne));
         self::assertTrue($validatorOne->isValid($hashTwo));
@@ -246,13 +240,17 @@ class CsrfTest extends TestCase
         $validatorOne = new Csrf();
         $validatorTwo = new Csrf(['name' => 'foo']);
 
-        $containerOne = $validatorOne->getSession();
-        $containerTwo = $validatorTwo->getSession();
+        $containerOne = $this->getReflectionProperty($validatorOne, 'session');
+        self::assertInstanceOf(Container::class, $containerOne);
+        $containerTwo = $this->getReflectionProperty($validatorTwo, 'session');
+        self::assertInstanceOf(Container::class, $containerTwo);
 
         self::assertNotSame($containerOne, $containerTwo);
 
-        $hashOne = $validatorOne->getHash();
-        $hashTwo = $validatorTwo->getHash();
+        $hashOne = $this->getReflectionProperty($validatorOne, 'hash');
+        self::assertIsString($hashOne);
+        $hashTwo = $this->getReflectionProperty($validatorTwo, 'hash');
+        self::assertIsString($hashTwo);
 
         self::assertTrue($validatorOne->isValid($hashOne));
         self::assertFalse($validatorOne->isValid($hashTwo));
@@ -262,29 +260,22 @@ class CsrfTest extends TestCase
 
     public function testCannotReValidateAnExpiredHash(): void
     {
-        $hash = $this->validator->getHash();
+        $hash = $this->getValidatorPropertyValue('hash');
+        self::assertIsString($hash);
 
         self::assertTrue($this->validator->isValid($hash));
         $requestTime = $_SERVER['REQUEST_TIME'] ?? null;
         self::assertIsNumeric($requestTime);
 
+        $container = $this->getValidatorPropertyValue('session');
+        self::assertInstanceOf(Container::class, $container);
+
         $this->sessionManager->getStorage()->setMetadata(
-            $this->validator->getSession()->getName(),
+            $container->getName(),
             ['EXPIRE' => $requestTime - 18600]
         );
 
         self::assertFalse($this->validator->isValid($hash));
-    }
-
-    public function testCanValidateHashWithoutId(): void
-    {
-        $method = new ReflectionMethod($this->validator::class, 'getTokenFromHash');
-
-        $hash      = $this->validator->getHash();
-        $bareToken = $method->invoke($this->validator, $hash);
-        self::assertIsString($bareToken);
-
-        self::assertTrue($this->validator->isValid($bareToken));
     }
 
     public function testCanRejectArrayValues(): void


### PR DESCRIPTION
Upgraded `laminas/laminas-servicemanager` to version 4, as well as the other dependencies required for it,  and added various Psalm tweaks.

I seems I was working on this PR alongside #102 , with the main difference seemingly being the removal of `v2` functions from the codebase in preparation for a new major release.

 I was about to make a different PR to the current branch marking the functions removed here as `deprecated`, but I'll wait for feedback regarding the desired way forward.