### PR TITLE
Move laminas-validator to require dependencies and bump the version with all dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,16 +34,16 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "laminas/laminas-eventmanager": "^3.12",
-        "laminas/laminas-servicemanager": "^3.22",
-        "laminas/laminas-stdlib": "^3.18"
+        "laminas/laminas-servicemanager": "^4.0",
+        "laminas/laminas-stdlib": "^3.18",
+        "laminas/laminas-validator": "^3.0"
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "laminas/laminas-cache": "^3.12.2",
-        "laminas/laminas-cache-storage-adapter-memory": "^2.3",
+        "laminas/laminas-cache": "^4.0",
+        "laminas/laminas-cache-storage-adapter-memory": "^3.0",
         "laminas/laminas-coding-standard": "~3.0.1",
         "laminas/laminas-http": "^2.20",
-        "laminas/laminas-validator": "^2.64.1",
         "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.19.0",
         "vimeo/psalm": "^5.26.1"
@@ -51,8 +51,7 @@
     "suggest": {
         "laminas/laminas-cache": "Laminas\\Cache component",
         "laminas/laminas-http": "Laminas\\Http component",
-        "laminas/laminas-servicemanager": "Laminas\\ServiceManager component",
-        "laminas/laminas-validator": "Laminas\\Validator component"
+        "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6319906222fbfb5f37ac072f41026096",
+    "content-hash": "c454104bb736a0603cf4053c89b68e06",
     "packages": [
+        {
+            "name": "brick/varexporter",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "vimeo/psalm": "5.15.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-01T21:10:07+00:00"
+        },
         {
             "name": "laminas/laminas-eventmanager",
             "version": "3.14.0",
@@ -76,59 +125,56 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.23.0",
+            "version": "4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b"
+                "reference": "74da44d07e493b834347123242d0047976fb9932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a8640182b892b99767d54404d19c5c3b3699f79b",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/74da44d07e493b834347123242d0047976fb9932",
+                "reference": "74da44d07e493b834347123242d0047976fb9932",
                 "shasum": ""
             },
             "require": {
+                "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0",
                 "laminas/laminas-stdlib": "^3.19",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1 || ^2.0"
             },
             "conflict": {
-                "ext-psr": "*",
                 "laminas/laminas-code": "<4.10.0",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
+                "zendframework/zend-code": "<3.3.1"
             },
             "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
+                "psr/container-implementation": "^1.0 || ^2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "friendsofphp/proxy-manager-lts": "^1.0.18",
-                "laminas/laminas-code": "^4.14.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-container-config-test": "^1.0",
                 "mikey179/vfsstream": "^1.6.12",
-                "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.26.1"
+                "phpbench/phpbench": "^1.4.0",
+                "phpunit/phpunit": "^10.5.44",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "symfony/console": "^6.4.17 || ^7.0",
+                "vimeo/psalm": "^6.2.0"
             },
             "suggest": {
-                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
+                "laminas/laminas-cli": "To consume CLI commands provided by this component"
             },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ServiceManager",
+                    "config-provider": "Laminas\\ServiceManager\\ConfigProvider"
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -150,11 +196,9 @@
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.4.0"
             },
             "funding": [
                 {
@@ -162,7 +206,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-28T21:32:16+00:00"
+            "time": "2025-02-04T06:13:50+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -224,23 +268,214 @@
             "time": "2024-10-29T13:46:07+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.1.2",
+            "name": "laminas/laminas-translator",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-21T15:33:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "734d564aea1b71a28d8142620957c40e272435b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/734d564aea1b71a28d8142620957c40e272435b7",
+                "reference": "734d564aea1b71a28d8142620957c40e272435b7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^4.1.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "laminas/laminas-translator": "^1.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/container": "^1.1 || ^2.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-diactoros": "^3.5.0",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "vimeo/psalm": "^6.8.8"
+            },
+            "suggest": {
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-validator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-validator/issues",
+                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
+                "source": "https://github.com/laminas/laminas-validator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-04-13T13:09:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.19.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
+            },
+            "time": "2024-09-29T15:01:53+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -267,9 +502,169 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
         }
     ],
     "packages-dev": [
@@ -1056,31 +1451,30 @@
         },
         {
             "name": "laminas/laminas-cache",
-            "version": "3.13.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "8225b16d03bbff2ecf2bd5a4f38c39ca47389e50"
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/8225b16d03bbff2ecf2bd5a4f38c39ca47389e50",
-                "reference": "8225b16d03bbff2ecf2bd5a4f38c39ca47389e50",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/557c34091fdee1791bc16ddc06af583f94caa2dd",
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-cache-storage-implementation": "1.0",
                 "laminas/laminas-eventmanager": "^3.4",
-                "laminas/laminas-servicemanager": "^3.21",
-                "laminas/laminas-stdlib": "^3.6",
+                "laminas/laminas-servicemanager": "^4.1",
+                "laminas/laminas-stdlib": "^3.20",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/cache": "^1.0",
+                "psr/cache": "^2.0 || ^3.0",
                 "psr/clock": "^1.0",
-                "psr/simple-cache": "^1.0",
-                "webmozart/assert": "^1.9"
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "webmozart/assert": "^1.11"
             },
             "conflict": {
-                "stella-maris/clock": "<0.1.7",
+                "laminas/laminas-serializer": "<3.0",
                 "symfony/console": "<5.1"
             },
             "provide": {
@@ -1088,20 +1482,13 @@
                 "psr/simple-cache-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-apcu": "^2.4",
-                "laminas/laminas-cache-storage-adapter-blackhole": "^2.3",
-                "laminas/laminas-cache-storage-adapter-filesystem": "^2.3",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2",
-                "laminas/laminas-cache-storage-adapter-test": "^2.4",
-                "laminas/laminas-cli": "^1.7",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-config-aggregator": "^1.13",
-                "laminas/laminas-feed": "^2.20",
-                "laminas/laminas-serializer": "^2.14",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.4"
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-config-aggregator": "^1.17",
+                "laminas/laminas-serializer": "^3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
@@ -1153,38 +1540,38 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-01-21T12:32:41+00:00"
+            "time": "2024-11-26T08:07:17+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
-            "version": "2.4.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
-                "reference": "12d2b191fee7ed0c08fd5db4441282705184f1bf"
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/12d2b191fee7ed0c08fd5db4441282705184f1bf",
-                "reference": "12d2b191fee7ed0c08fd5db4441282705184f1bf",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/10f0d64c0b3e381a8baaca108803111aa7b110db",
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-cache": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "laminas/laminas-servicemanager": "<3.11"
+                "laminas/laminas-cache": "^4.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
             },
             "provide": {
-                "laminas/laminas-cache-storage-implementation": "1.0"
+                "laminas/laminas-cache-storage-implementation": "2.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-benchmark": "^1.1.0",
-                "laminas/laminas-cache-storage-adapter-test": "^2.3.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^4.29.0"
+                "laminas/laminas-cache-storage-adapter-benchmark": "^2.0",
+                "laminas/laminas-cache-storage-adapter-test": "^4.1",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "lcobucci/clock": "^3.0",
+                "lctrs/psalm-psr-container-plugin": "^1.10",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.24"
             },
             "type": "library",
             "extra": {
@@ -1220,7 +1607,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-01-23T15:41:59+00:00"
+            "time": "2024-11-27T08:14:09+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1517,90 +1904,6 @@
             "time": "2024-12-03T12:27:51+00:00"
         },
         {
-            "name": "laminas/laminas-validator",
-            "version": "2.64.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "771e504760448ac7af660710237ceb93be602e08"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
-                "reference": "771e504760448ac7af660710237ceb93be602e08",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.19",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/http-message": "^1.0.1 || ^2.0.0"
-            },
-            "conflict": {
-                "zendframework/zend-validator": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5",
-                "laminas/laminas-db": "^2.20",
-                "laminas/laminas-filter": "^2.35.2",
-                "laminas/laminas-i18n": "^2.26.0",
-                "laminas/laminas-session": "^2.20",
-                "laminas/laminas-uri": "^2.11.0",
-                "phpunit/phpunit": "^10.5.20",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "psr/http-client": "^1.0.3",
-                "psr/http-factory": "^1.1.0",
-                "vimeo/psalm": "^5.24.0"
-            },
-            "suggest": {
-                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
-                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
-                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-                "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
-                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
-                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Validator",
-                    "config-provider": "Laminas\\Validator\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Validator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "validator"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-validator/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-validator/issues",
-                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
-                "source": "https://github.com/laminas/laminas-validator"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-11-26T21:29:17+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.13.0",
             "source": {
@@ -1710,62 +2013,6 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
             },
             "time": "2024-09-08T10:13:13+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.19.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
-            },
-            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2591,20 +2838,20 @@
         },
         {
             "name": "psr/cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
@@ -2624,7 +2871,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -2634,9 +2881,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/clock",
@@ -2685,59 +2932,6 @@
                 "source": "https://github.com/php-fig/clock/tree/1.0.0"
             },
             "time": "2022-11-25T14:36:26+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2791,25 +2985,25 @@
         },
         {
             "name": "psr/simple-cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2824,7 +3018,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for simple caching",
@@ -2836,9 +3030,9 @@
                 "simple-cache"
             ],
             "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
-            "time": "2017-10-23T01:57:42+00:00"
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -278,9 +278,6 @@
       <code><![CDATA[null|string]]></code>
       <code><![CDATA[string|null]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument>
-      <code><![CDATA[HostnameValidator::ALLOW_ALL]]></code>
-    </InvalidArgument>
     <InvalidReturnType>
       <code><![CDATA[mixed]]></code>
     </InvalidReturnType>
@@ -461,14 +458,8 @@
       <code><![CDATA[$sessionName]]></code>
       <code><![CDATA[$sessionSavePath]]></code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $this->getCacheStorage()->removeItem($id)]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Service/ContainerAbstractServiceFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[ContainerAbstractServiceFactory]]></code>
-    </DeprecatedInterface>
     <MissingConstructor>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$sessionManager]]></code>
@@ -491,52 +482,25 @@
       <code><![CDATA[$this->sessionManager]]></code>
       <code><![CDATA[$this->sessionManager]]></code>
     </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[$this->sessionManager !== null]]></code>
       <code><![CDATA[null !== $this->config]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Service/SessionConfigFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[SessionConfigFactory]]></code>
-    </DeprecatedInterface>
     <MixedMethodCall>
       <code><![CDATA[new $class()]]></code>
     </MixedMethodCall>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Service/SessionManagerFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[SessionManagerFactory]]></code>
-    </DeprecatedInterface>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$manager]]></code>
-    </LessSpecificReturnStatement>
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$configService]]></code>
-      <code><![CDATA[$options]]></code>
       <code><![CDATA[$saveHandler]]></code>
       <code><![CDATA[$storage]]></code>
-      <code><![CDATA[$validators]]></code>
     </MixedAssignment>
-    <MoreSpecificReturnType>
-      <code><![CDATA[SessionManager]]></code>
-    </MoreSpecificReturnType>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Service/StorageFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[StorageFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$type]]></code>
@@ -546,9 +510,6 @@
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$type]]></code>
     </MixedAssignment>
-    <ParamNameMismatch>
-      <code><![CDATA[$services]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/SessionManager.php">
     <DocblockTypeContradiction>
@@ -1233,54 +1194,18 @@
     <MissingReturnType>
       <code><![CDATA[testServiceNotCreatedWhenInvalidSamesiteConfig]]></code>
     </MissingReturnType>
-    <MixedAssignment>
-      <code><![CDATA[$config]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[getName]]></code>
-    </MixedMethodCall>
   </file>
   <file src="test/Service/SessionManagerFactoryTest.php">
-    <MixedArgument>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$manager]]></code>
-    </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$listener[0]]]></code>
       <code><![CDATA[$validatorData[Validator\HttpUserAgent::class]]]></code>
       <code><![CDATA[$validatorData[Validator\RemoteAddr::class]]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$chain]]></code>
-      <code><![CDATA[$chain]]></code>
       <code><![CDATA[$listener]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
-      <code><![CDATA[$manager]]></code>
       <code><![CDATA[$validatorData]]></code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[getConfig]]></code>
-      <code><![CDATA[getSaveHandler]]></code>
-      <code><![CDATA[getStorage]]></code>
-      <code><![CDATA[getStorage]]></code>
-      <code><![CDATA[getValidatorChain]]></code>
-      <code><![CDATA[getValidatorChain]]></code>
-      <code><![CDATA[start]]></code>
-      <code><![CDATA[start]]></code>
-      <code><![CDATA[start]]></code>
-    </MixedMethodCall>
     <UnusedVariable>
-      <code><![CDATA[$manager]]></code>
       <code><![CDATA[$manager]]></code>
     </UnusedVariable>
   </file>
@@ -1289,14 +1214,6 @@
       <code><![CDATA[$config['session_storage']['options']]]></code>
       <code><![CDATA[$config['session_storage']['options']['input']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$storage]]></code>
-      <code><![CDATA[$storage]]></code>
-      <code><![CDATA[$test]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[toArray]]></code>
-    </MixedMethodCall>
     <UnusedVariable>
       <code><![CDATA[$storage]]></code>
     </UnusedVariable>

--- a/src/Config/StandardConfig.php
+++ b/src/Config/StandardConfig.php
@@ -492,7 +492,9 @@ class StandardConfig implements ConfigInterface, SameSiteCookieCapableInterface
             throw new Exception\InvalidArgumentException('Invalid cookie domain: must be a string');
         }
 
-        $validator = new HostnameValidator(HostnameValidator::ALLOW_ALL);
+        $validator = new HostnameValidator([
+            'allow' => HostnameValidator::ALLOW_ALL,
+        ]);
 
         if (! empty($cookieDomain) && ! $validator->isValid($cookieDomain)) {
             throw new Exception\InvalidArgumentException(

--- a/src/SaveHandler/Cache.php
+++ b/src/SaveHandler/Cache.php
@@ -73,11 +73,11 @@ class Cache implements SaveHandlerInterface
     /**
      * Read session data
      *
-     * @param string $id
+     * @param non-empty-string $id
      * @return string
      */
     #[ReturnTypeWillChange]
-    public function read($id)
+    public function read(string $id)
     {
         return (string) $this->getCacheStorage()->getItem($id);
     }
@@ -85,12 +85,12 @@ class Cache implements SaveHandlerInterface
     /**
      * Write session data
      *
-     * @param string $id
+     * @param non-empty-string $id
      * @param string $data
      * @return bool
      */
     #[ReturnTypeWillChange]
-    public function write($id, $data)
+    public function write(string $id, $data)
     {
         return $this->getCacheStorage()->setItem($id, $data);
     }
@@ -98,18 +98,18 @@ class Cache implements SaveHandlerInterface
     /**
      * Destroy session
      *
-     * @param string $id
+     * @param non-empty-string $id
      * @return bool
      */
     #[ReturnTypeWillChange]
-    public function destroy($id)
+    public function destroy(string $id)
     {
         $this->getCacheStorage()->getItem($id, $exists);
-        if (! (bool) $exists) {
+        if (! $exists) {
             return true;
         }
 
-        return (bool) $this->getCacheStorage()->removeItem($id);
+        return $this->getCacheStorage()->removeItem($id);
     }
 
     /**

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -4,11 +4,10 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\AbstractFactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\Session\Container;
 use Laminas\Session\ManagerInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_change_key_case;
 use function array_flip;
@@ -58,11 +57,8 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Can we create an instance of the given service? (v3 usage).
-     *
-     * @param string $requestedName
-     * @return bool
      */
-    public function canCreate(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, string $requestedName): bool
     {
         $config = $this->getConfig($container);
         if ($config === []) {
@@ -74,41 +70,14 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @deprecated This method will be removed in version 3.0
-     * Can we create an instance of the given service? (v2 usage)
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @return bool
-     */
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this->canCreate($container, $requestedName);
-    }
-
-    /**
      * Create and return a named container (v3 usage).
      *
-     * @param string $requestedName
      * @return Container
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): mixed
     {
         $manager = $this->getSessionManager($container);
         return new Container($requestedName, $manager);
-    }
-
-    /**
-     * @deprecated This method will be removed in version 3.0
-     * Create and return a named container (v2 usage).
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @return Container
-     */
-    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this($container, $requestedName);
     }
 
     /**

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -4,21 +4,19 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\SameSiteCookieCapableInterface;
 use Laminas\Session\Config\SessionConfig;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
+use Psr\Container\ContainerInterface;
 
 use function class_exists;
 use function get_debug_type;
 use function is_array;
 use function sprintf;
 
-class SessionConfigFactory implements FactoryInterface
+class SessionConfigFactory
 {
     /**
      * Create session configuration object (v3 usage).
@@ -28,13 +26,10 @@ class SessionConfigFactory implements FactoryInterface
      * you may also specify a specific implementation variant using the
      * "config_class" subkey.
      *
-     * @param string $requestedName
-     * @param null|array $options
-     * @return ConfigInterface
      * @throws ServiceNotCreatedException If session_config is missing, or an
      *     invalid config_class is used.
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container): ConfigInterface
     {
         $config = $container->get('config');
         if (! isset($config['session_config']) || ! is_array($config['session_config'])) {
@@ -114,21 +109,5 @@ class SessionConfigFactory implements FactoryInterface
         $sessionConfig->setOptions($config);
 
         return $sessionConfig;
-    }
-
-    /**
-     * @deprecated This method will be removed in version 3.0
-     * Create and return a config instance (v2 usage).
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return ConfigInterface
-     */
-    public function createService(
-        ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = ConfigInterface::class
-    ) {
-        return $this($services, $requestedName);
     }
 }

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -4,25 +4,20 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Container;
-use Laminas\Session\ManagerInterface;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\SessionManager;
 use Laminas\Session\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_merge;
-use function class_exists;
 use function get_debug_type;
 use function is_array;
-use function is_subclass_of;
 use function sprintf;
 
-class SessionManagerFactory implements FactoryInterface
+class SessionManagerFactory
 {
     /**
      * Default configuration for manager behavior
@@ -58,11 +53,8 @@ class SessionManagerFactory implements FactoryInterface
      *   as the default manager for Container instances. The default value for
      *   this is true; set it to false to disable.
      * - validators: ...
-     *
-     * @param string $requestedName
-     * @return SessionManager
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container): SessionManager
     {
         $config        = null;
         $storage       = null;
@@ -117,25 +109,16 @@ class SessionManagerFactory implements FactoryInterface
                 $managerConfig = array_merge($managerConfig, $configService['session_manager']);
             }
 
-            if (isset($managerConfig['validators'])) {
+            if (isset($managerConfig['validators']) && is_array($managerConfig['validators'])) {
                 $validators = $managerConfig['validators'];
             }
 
-            if (isset($managerConfig['options'])) {
+            if (isset($managerConfig['options']) && is_array($managerConfig['options'])) {
                 $options = $managerConfig['options'];
             }
         }
 
-        $managerClass = class_exists($requestedName) ? $requestedName : SessionManager::class;
-        if (! is_subclass_of($managerClass, ManagerInterface::class)) {
-            throw new ServiceNotCreatedException(sprintf(
-                'SessionManager requires that the %s service implement %s',
-                $managerClass,
-                ManagerInterface::class
-            ));
-        }
-
-        $manager = new $managerClass($config, $storage, $saveHandler, $validators, $options);
+        $manager = new SessionManager($config, $storage, $saveHandler, $validators, $options);
 
         // If configuration enables the session manager as the default manager for container
         // instances, do so.
@@ -147,21 +130,5 @@ class SessionManagerFactory implements FactoryInterface
         }
 
         return $manager;
-    }
-
-    /**
-     * @deprecated This method will be removed in version 3.0
-     * Create a SessionManager instance (v2 usage)
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return SessionManager
-     */
-    public function createService(
-        ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = SessionManager::class
-    ) {
-        return $this($services, $requestedName);
     }
 }

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -4,18 +4,16 @@ namespace Laminas\Session\Service;
 
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Exception\ExceptionInterface as SessionException;
 use Laminas\Session\Storage\Factory;
 use Laminas\Session\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 use function sprintf;
 
-class StorageFactory implements FactoryInterface
+class StorageFactory
 {
     /**
      * Create session storage object (v3 usage).
@@ -25,12 +23,10 @@ class StorageFactory implements FactoryInterface
      * type to use, and optionally "options", containing any options to be used in
      * creating the StorageInterface instance.
      *
-     * @param string $requestedName
-     * @return StorageInterface
      * @throws ServiceNotCreatedException If session_storage is missing, or the
      *         factory cannot create the storage instance.
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container): StorageInterface
     {
         $config = $container->get('config');
         if (! isset($config['session_storage']) || ! is_array($config['session_storage'])) {
@@ -58,21 +54,5 @@ class StorageFactory implements FactoryInterface
         }
 
         return $storage;
-    }
-
-    /**
-     * @deprecated This method will be removed in version 3.0
-     * Create and return a storage instance (v2 usage).
-     *
-     * @param null|string $canonicalName
-     * @param string $requestedName
-     * @return StorageInterface
-     */
-    public function createService(
-        ServiceLocatorInterface $services,
-        $canonicalName = null,
-        $requestedName = StorageInterface::class
-    ) {
-        return $this($services, $requestedName);
     }
 }

--- a/src/Validator/Csrf.php
+++ b/src/Validator/Csrf.php
@@ -7,6 +7,7 @@ namespace Laminas\Session\Validator;
 use Laminas\Session\Container;
 use Laminas\Validator\AbstractValidator;
 
+use function array_key_exists;
 use function assert;
 use function explode;
 use function is_array;
@@ -53,26 +54,30 @@ final class Csrf extends AbstractValidator
      *
      * @var non-empty-string
      */
-    private string $name = 'csrf';
+    private string $name;
 
     /**
      * Salt for CSRF token
      *
      * @var non-empty-string
      */
-    private string $salt = 'salt';
+    private string $salt;
 
-    private ?Container $session = null;
+    private ?Container $session;
 
     /**
      * TTL for CSRF token
      */
-    private int|null $timeout = 300;
+    private int|null $timeout;
 
     /** @param OptionsArgument $options */
     public function __construct(array $options = [])
     {
         parent::__construct($options);
+        $this->name    = $options['name'] ?? 'csrf';
+        $this->salt    = $options['salt'] ?? 'salt';
+        $this->session = $options['session'] ?? null;
+        $this->timeout = array_key_exists('timeout', $options) ? $options['timeout'] : 300;
     }
 
     /**

--- a/test/Service/SessionConfigFactoryTest.php
+++ b/test/Service/SessionConfigFactoryTest.php
@@ -153,7 +153,7 @@ class SessionConfigFactoryTest extends TestCase
 
         $factory = new SessionConfigFactory();
         /** @var SessionConfig $config */
-        $config = $factory($mockContainer, ConfigInterface::class);
+        $config = $factory($mockContainer);
 
         self::assertInstanceOf(SessionConfig::class, $config);
         /** @noinspection PhpUndefinedMethodInspection This will always exist in SessionConfig */
@@ -185,7 +185,7 @@ class SessionConfigFactoryTest extends TestCase
                       ]);
 
         $factory = new SessionConfigFactory();
-        $config  = $factory($mockContainer, ConfigInterface::class);
+        $config  = $factory($mockContainer);
 
         self::assertInstanceOf(SessionConfig::class, $config);
         /** @noinspection PhpUndefinedMethodInspection This will always exist in SessionConfig */

--- a/test/Service/SessionManagerFactoryTest.php
+++ b/test/Service/SessionManagerFactoryTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Session\Service;
 
+use Laminas\EventManager\EventManager;
 use Laminas\EventManager\Test\EventListenerIntrospectionTrait;
-use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Container;
@@ -17,11 +17,10 @@ use Laminas\Session\Storage\ArrayStorage;
 use Laminas\Session\Storage\StorageInterface;
 use Laminas\Session\Validator;
 use LaminasTest\Session\ReflectionPropertyTrait;
-use LaminasTest\Session\TestAsset\TestManager;
-use LaminasTest\Session\TestAsset\TestSaveHandler;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
+use function assert;
 use function iterator_to_array;
 
 /**
@@ -39,8 +38,6 @@ class SessionManagerFactoryTest extends TestCase
         $this->services = new ServiceManager([
             'factories' => [
                 ManagerInterface::class => SessionManagerFactory::class,
-                TestManager::class      => SessionManagerFactory::class,
-                TestSaveHandler::class  => SessionManagerFactory::class,
             ],
         ]);
     }
@@ -114,7 +111,8 @@ class SessionManagerFactoryTest extends TestCase
 
         $manager->start();
 
-        $chain     = $manager->getValidatorChain();
+        $chain = $manager->getValidatorChain();
+        assert($chain instanceof EventManager);
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
     }
@@ -198,7 +196,8 @@ class SessionManagerFactoryTest extends TestCase
             // Ignore exception, because we are not interested whether session validation passes in this test
         }
 
-        $chain     = $manager->getValidatorChain();
+        $chain = $manager->getValidatorChain();
+        assert($chain instanceof EventManager);
         $listeners = iterator_to_array($this->getListenersForEvent('session.validate', $chain));
         self::assertCount(2, $listeners);
 
@@ -232,17 +231,5 @@ class SessionManagerFactoryTest extends TestCase
 
         $containedValidators = $this->getReflectionProperty($manager, 'validators');
         self::assertSame([], $containedValidators);
-    }
-
-    public function testFactoryWillUseRequestedNameAsSessionManagerIfItImplementsManagerInterface(): void
-    {
-        $manager = $this->services->get(TestManager::class);
-        self::assertInstanceOf(TestManager::class, $manager);
-    }
-
-    public function testFactoryWillRaiseServiceNotCreatedExceptionIfRequestedNameIsNotAManagerInterfaceSubclass(): void
-    {
-        $this->expectException(ServiceNotCreatedException::class);
-        $manager = $this->services->get(TestSaveHandler::class);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes


### Description
Moved laminas-validator to the require section and bumped directly the version to `^3.0`. This required to update some more dependencies and fix issues in the factories afterward. 

I tried to make this PR as small as possible and didn't added typehints for methods that doesn't require it yet. 

Relates to #114 