### PR TITLE
Add native types and template annotation for the ValidatorInterface

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1319,9 +1319,4 @@
       <code><![CDATA[$backup]]></code>
     </MissingConstructor>
   </file>
-  <file src="test/Validator/ValidatorChainTest.php">
-    <NoInterfaceProperties>
-      <code><![CDATA[$validator::$isValidCallCount]]></code>
-    </NoInterfaceProperties>
-  </file>
 </files>

--- a/src/Validator/HttpUserAgent.php
+++ b/src/Validator/HttpUserAgent.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Session\Validator;
 
+/**
+ * @implements ValidatorInterface<string>
+ */
 class HttpUserAgent implements ValidatorInterface
 {
     /**
@@ -30,10 +33,8 @@ class HttpUserAgent implements ValidatorInterface
     /**
      * isValid() - this method will determine if the current user agent matches the
      * user agent we stored when we initialized this variable.
-     *
-     * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? null;
 
@@ -42,20 +43,16 @@ class HttpUserAgent implements ValidatorInterface
 
     /**
      * Retrieve token for validating call
-     *
-     * @return string
      */
-    public function getData()
+    public function getData(): mixed
     {
         return $this->data;
     }
 
     /**
      * Return validator name
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return self::class;
     }

--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -13,6 +13,8 @@ use function substr;
 
 /**
  * session_id validator
+ *
+ * @implements ValidatorInterface<string>
  */
 class Id implements ValidatorInterface
 {
@@ -44,10 +46,8 @@ class Id implements ValidatorInterface
      * Is the current session identifier valid?
      *
      * Tests that the identifier does not contain invalid characters.
-     *
-     * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         $id          = $this->id;
         $saveHandler = ini_get('session.save_handler');
@@ -75,20 +75,16 @@ class Id implements ValidatorInterface
 
     /**
      * Retrieve token for validating call (session_id)
-     *
-     * @return string
      */
-    public function getData()
+    public function getData(): mixed
     {
         return $this->id;
     }
 
     /**
      * Return validator name
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return self::class;
     }

--- a/src/Validator/RemoteAddr.php
+++ b/src/Validator/RemoteAddr.php
@@ -7,6 +7,9 @@ namespace Laminas\Session\Validator;
 use Laminas\Http\PhpEnvironment\RemoteAddress;
 use Laminas\Session\Validator\ValidatorInterface as SessionValidator;
 
+/**
+ * @implements SessionValidator<string>
+ */
 class RemoteAddr implements SessionValidator
 {
     /**
@@ -59,10 +62,8 @@ class RemoteAddr implements SessionValidator
     /**
      * isValid() - this method will determine if the current user IP matches the
      * IP we stored when we initialized this variable.
-     *
-     * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         return $this->getIpAddress() === $this->getData();
     }
@@ -128,20 +129,16 @@ class RemoteAddr implements SessionValidator
 
     /**
      * Retrieve token for validating call
-     *
-     * @return string
      */
-    public function getData()
+    public function getData(): mixed
     {
         return $this->data;
     }
 
     /**
      * Return validator name
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return self::class;
     }

--- a/src/Validator/ValidatorInterface.php
+++ b/src/Validator/ValidatorInterface.php
@@ -6,6 +6,8 @@ namespace Laminas\Session\Validator;
 
 /**
  * Session validator interface
+ *
+ * @template T
  */
 interface ValidatorInterface
 {
@@ -13,22 +15,18 @@ interface ValidatorInterface
      * This method will be called at the beginning of
      * every session to determine if the current environment matches
      * that which was store in the setup() procedure.
-     *
-     * @return bool
      */
-    public function isValid();
+    public function isValid(): bool;
 
     /**
      * Get data from validator to be used for validation comparisons
      *
-     * @return mixed
+     * @return T
      */
-    public function getData();
+    public function getData(): mixed;
 
     /**
      * Get validator name for use with storing validators between requests
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 }

--- a/test/Validator/StaticValidatorStub.php
+++ b/test/Validator/StaticValidatorStub.php
@@ -2,15 +2,23 @@
 
 declare(strict_types=1);
 
-namespace LaminasTest\Session\TestAsset;
+namespace LaminasTest\Session\Validator;
 
 use Laminas\Session\Validator\ValidatorInterface;
 
 /**
  * @implements ValidatorInterface<false>
  */
-final class TestFailingValidator implements ValidatorInterface
+class StaticValidatorStub implements ValidatorInterface
 {
+    public static int $isValidCallCount = 0;
+
+    public function isValid(): bool
+    {
+        self::$isValidCallCount++;
+        return $this->getData();
+    }
+
     public function getData(): mixed
     {
         return false;
@@ -19,10 +27,5 @@ final class TestFailingValidator implements ValidatorInterface
     public function getName(): string
     {
         return self::class;
-    }
-
-    public function isValid(): bool
-    {
-        return $this->getData();
     }
 }

--- a/test/Validator/ValidatorChainTest.php
+++ b/test/Validator/ValidatorChainTest.php
@@ -5,13 +5,9 @@ declare(strict_types=1);
 namespace LaminasTest\Session\Validator;
 
 use Laminas\Session\Storage\ArrayStorage;
-use Laminas\Session\Validator\ValidatorInterface;
 use Laminas\Session\ValidatorChain;
 use LaminasTest\Session\TestAsset\TestFailingValidator;
 use PHPUnit\Framework\TestCase;
-
-use function assert;
-use function property_exists;
 
 class ValidatorChainTest extends TestCase
 {
@@ -42,38 +38,13 @@ class ValidatorChainTest extends TestCase
 
     public function testExistingValidatorsAreAttached(): void
     {
-        $validator = $this->createValidatorSpy();
+        $validator = new StaticValidatorStub();
         $storage   = new ArrayStorage();
         $storage->setMetadata('_VALID', [$validator::class => $validator->getData()]);
 
         $this->validatorChain = new ValidatorChain($storage);
 
         $this->validatorChain->trigger('session.validate');
-        assert(property_exists($validator, 'isValidCallCount'));
         self::assertSame(1, $validator::$isValidCallCount);
-    }
-
-    private function createValidatorSpy(): ValidatorInterface
-    {
-        return new class implements ValidatorInterface {
-            /** @var int */
-            public static $isValidCallCount = 0;
-
-            public function isValid(): bool
-            {
-                self::$isValidCallCount++;
-                return $this->getData();
-            }
-
-            public function getData(): bool
-            {
-                return false;
-            }
-
-            public function getName(): string
-            {
-                return self::class;
-            }
-        };
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes

### Description

Based on issue #113 and continuing the PR #135 - added native method and return types to the "ValidatorInterface" only, to keep it easier to review.

This should hopefully not affect the existing PRs #137, #136 and #132 which aims to make the validator itself better. This PR does not aim to solve the same problems, only to make the classes match the interface. 