### PR TITLE
PHP8.4: disable ID validator

### DIFF
--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -47,6 +47,12 @@ class Id implements ValidatorInterface
      */
     public function isValid()
     {
+        if (PHP_VERSION_ID > 80400) {
+            // PHP 8.4 deprecated session.sid_bits_per_character and set it to "4" hard.
+            // Old (pre PHP 8.4) with a higher bitrate are still valid though.
+            return true;
+        }
+
         $id          = $this->id;
         $saveHandler = ini_get('session.save_handler');
         if ($saveHandler === 'cluster') { // Zend Server SC, validate only after last dash


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

- Have a project with PHP 8.3 and session.sid_bits_per_character > 4
- Visit web page to create a valid session ID
- Upgrade PHP to 8.4
- Visit web page - blank - "Session validation failed"
- Set attach_default_validators to false
- Visit web page again - still blank - "Session validation failed"
- Delete all session files OR delete the session cookie on all clients (unrealistic on any scale, but doable in dev)
- Visit web page again - session is gone and web page works again.

The reason is, that PHP 8.4+ ALWAYS returns "4" for session.sid_bits_per_character. But it seems like PHP 8.4 happily accepts valid session with > 4. It will just generate NEW session ID with just 4 bits per char.
So PHP accepts the old session ID, but the validator does not and it will crash out.
