### PR TITLE
PHP8.4: disable ID validator

### DIFF
--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -9,6 +9,8 @@ use function session_id;
 use function strrpos;
 use function substr;
 
+use const PHP_VERSION_ID;
+
 /**
  * session_id validator
  */
@@ -47,12 +49,6 @@ class Id implements ValidatorInterface
      */
     public function isValid()
     {
-        if (PHP_VERSION_ID >= 80400) {
-            // PHP 8.4 deprecated session.sid_bits_per_character and set it to "4" hard.
-            // Old (pre PHP 8.4) session IDs with a higher bitrate are still valid though.
-            return true;
-        }
-
         $id          = $this->id;
         $saveHandler = ini_get('session.save_handler');
         if ($saveHandler === 'cluster') { // Zend Server SC, validate only after last dash
@@ -62,9 +58,15 @@ class Id implements ValidatorInterface
             }
         }
 
-        // Get the session id bits per character INI setting, using 5 if unavailable
-        $hashBitsPerChar = ini_get('session.sid_bits_per_character');
-        $hashBitsPerChar = is_numeric($hashBitsPerChar) ? (int) $hashBitsPerChar : 5;
+        if (PHP_VERSION_ID >= 80400) {
+            // PHP 8.4 deprecated session.sid_bits_per_character and set it hard to "4".
+            // Old (pre PHP 8.4) session IDs with a higher bitrate are still valid though.
+            $hashBitsPerChar = 6;
+        } else {
+            // Get the session id bits per character INI setting, using 5 if unavailable
+            $hashBitsPerChar = ini_get('session.sid_bits_per_character');
+            $hashBitsPerChar = is_numeric($hashBitsPerChar) ? (int) $hashBitsPerChar : 5;
+        }
 
         $pattern = match ($hashBitsPerChar) {
             4 => '#^[0-9a-f]*$#',

--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -47,6 +47,12 @@ class Id implements ValidatorInterface
      */
     public function isValid()
     {
+        if (PHP_VERSION_ID >= 80400) {
+            // PHP 8.4 deprecated session.sid_bits_per_character and set it to "4" hard.
+            // Old (pre PHP 8.4) session IDs with a higher bitrate are still valid though.
+            return true;
+        }
+
         $id          = $this->id;
         $saveHandler = ini_get('session.save_handler');
         if ($saveHandler === 'cluster') { // Zend Server SC, validate only after last dash

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -818,7 +818,7 @@ class SessionManagerTest extends TestCase
     {
         $this->manager = new SessionManager();
         $this->manager->getValidatorChain()
-            ->attach('session.validate', [new Id('invalid-value'), 'isValid']);
+            ->attach('session.validate', [new Id('invalid.value'), 'isValid']);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Session validation failed');

--- a/test/Validator/IdTest.php
+++ b/test/Validator/IdTest.php
@@ -12,32 +12,41 @@ use function ini_set;
 use function session_id;
 use function session_start;
 
+use const PHP_VERSION_ID;
+
 class IdTest extends TestCase
 {
-    /** @psalm-return iterable<string, array{0: int, 1: string, 2: bool}> */
+    /** @psalm-return iterable<string, array{0: int, 1: string, 2: bool, 3: bool}> */
     public static function id(): iterable
     {
-        yield '4, valid' => [4, '0123456789abcdef', true];
-        yield '4, invalid (out of the range)' => [4, '0123456789abcdefg', false];
-        yield '4, invalid (uppercase characters)' => [4, '0123456789ABCDEF', false];
+        yield '4, valid' => [4, '0123456789abcdef', true, true];
+        yield '4, invalid (out of the range)' => [4, '0123456789abcdefg', false, true];
+        yield '4, invalid (uppercase characters)' => [4, '0123456789ABCDEF', false, true];
+        yield '4, invalid (out of the range with a dot)' => [4, '0123456789ABCDEF.123', false, false];
 
-        yield '5, valid' => [5, '0123456789abcdefghijklmnopqrstuv', true];
-        yield '5, invalid (out of the range)' => [5, '0123456789abcdefghijklmnopqrstuvw', false];
-        yield '5, invalid (uppercase characters)' => [5, '0123456789ABCDEFGHIJKLMNOPQRSTUV', false];
+        yield '5, valid' => [5, '0123456789abcdefghijklmnopqrstuv', true, true];
+        yield '5, invalid (out of the range)' => [5, '0123456789abcdefghijklmnopqrstuvw', false, true];
+        yield '5, invalid (uppercase characters)' => [5, '0123456789ABCDEFGHIJKLMNOPQRSTUV', false, true];
+        yield '5, invalid (out of the range with a dot)' => [5, '0123456789ABCDEFGHIJKLMNOPQRSTUV.123', false, false];
 
-        yield '6, valid' => [6, '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-,', true];
-        yield '6, invalid (out of the range)' => [6, '0123456789.abcdefghijklmnopqrstuvwxyz', false];
+        yield '6, valid' => [6, '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-,', true, true];
+        yield '6, invalid (out of the range)' => [6, '0123456789.abcdefghijklmnopqrstuvwxyz', false, false];
     }
 
     #[IgnoreDeprecations]
     #[DataProvider('id')]
     #[RunInSeparateProcess]
-    public function testIsValidPhp71(int $bitsPerCharacter, string $id, bool $isValid): void
+    public function testIsValidPhp71(int $bitsPerCharacter, string $id, bool $isValidPhpPre84, bool $isValidPhp84): void
     {
         ini_set('session.sid_bits_per_character', $bitsPerCharacter);
 
         $validator = new Id($id);
-        self::assertSame($isValid, $validator->isValid());
+
+        if (PHP_VERSION_ID >= 80400) {
+            self::assertSame($isValidPhp84, $validator->isValid());
+        } else {
+            self::assertSame($isValidPhpPre84, $validator->isValid());
+        }
     }
 
     public function testConstructorSetId(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

- Have a project with PHP 8.3 and session.sid_bits_per_character > 4
- Visit web page to create a valid session ID
- Upgrade PHP to 8.4
- Visit web page - blank - "Session validation failed"
- Set attach_default_validators to false
- Visit web page again - still blank - "Session validation failed"
- Delete all session files OR delete the session cookie on all clients (unrealistic on any scale, but doable in dev)
- Visit web page again - session is gone and web page works again.

The reason is, that PHP 8.4+ ALWAYS returns "4" for session.sid_bits_per_character. But it seems like PHP 8.4 happily accepts valid session with > 4. It will just generate NEW session ID with just 4 bits per char.
So PHP accepts the old session ID, but the validator does not and it will crash out.
