### PR TITLE
Strict manager interface

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -39,3 +39,15 @@ The implementation of the `SessionManager::sessionExists()` method has been simp
 
 > NOTE: **Logical change**
 > Due to this implementation change, `sessionExists()` will now return `false` after `session_close()` has been called, whereas in version 2 it would return `true`.
+
+### Native Types for `ManagerInterface`
+
+Starting from version 3.0, the `ManagerInterface` now uses native PHP 8 type hints for all its methods.
+
+If you have custom classes implementing `ManagerInterface`, you'll need to update your method signatures to match the new interface.
+In addition to the method signature changes, there are several other important modifications:
+
+1. The `Laminas\Session\SessionManager` class is now marked as `final`, so it can no longer be extended
+2. The `setId()` method now only accepts `string` type instead of the previous `int|string` union type
+3. Options like `send_expire_cookie`, `clear_storage` and `preserve_storage` could be set during construction and will be used in `destroy()` and `start()` method calls if the parameter will be passed as null.
+4. All validator types are strictly defined as `class-string<ValidatorInterface>`

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -94,9 +94,6 @@
       <code><![CDATA[new $this->defaultConfigClass()]]></code>
       <code><![CDATA[new $this->defaultStorageClass()]]></code>
     </MixedMethodCall>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$saveHandler]]></code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Config/ConfigInterface.php">
     <PossiblyUnusedMethod>
@@ -171,12 +168,12 @@
       <code><![CDATA[setStorage]]></code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[self]]></code>
-      <code><![CDATA[self]]></code>
-      <code><![CDATA[self]]></code>
-      <code><![CDATA[self]]></code>
-      <code><![CDATA[self]]></code>
-      <code><![CDATA[self]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/SaveHandler/Cache.php">
@@ -231,22 +228,12 @@
     </MixedAssignment>
   </file>
   <file src="src/SessionManager.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[null === $this->name]]></code>
-      <code><![CDATA[null === $this->validatorChain]]></code>
-    </DocblockTypeContradiction>
     <MissingClosureParamType>
       <code><![CDATA[$test]]></code>
     </MissingClosureParamType>
-    <MissingReturnType>
-      <code><![CDATA[initializeValidatorChain]]></code>
-    </MissingReturnType>
     <MixedAssignment>
       <code><![CDATA[$validatorValues]]></code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$id]]></code>
-    </MoreSpecificImplementedParamType>
     <NoValue>
       <code><![CDATA[$oldSessionData]]></code>
     </NoValue>
@@ -256,17 +243,6 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-    </PossiblyUnusedReturnValue>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$validatorChain]]></code>
-      <code><![CDATA[SessionManager]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $deleteOldSession]]></code>
-    </RedundantCastGivenDocblockType>
     <RedundantCondition>
       <code><![CDATA[! empty($oldSessionData) && is_array($oldSessionData)]]></code>
       <code><![CDATA[is_array($oldSessionData)]]></code>
@@ -274,6 +250,9 @@
     <TypeDoesNotContainType>
       <code><![CDATA[$oldSessionData instanceof Traversable]]></code>
     </TypeDoesNotContainType>
+    <UnusedReturnValue>
+      <code><![CDATA[bool]]></code>
+    </UnusedReturnValue>
   </file>
   <file src="src/Storage/AbstractSessionArrayStorage.php">
     <ImplementedParamTypeMismatch>
@@ -434,8 +413,6 @@
       <code><![CDATA[static]]></code>
       <code><![CDATA[static]]></code>
       <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/ValidatorChain.php">
@@ -473,111 +450,6 @@
       <code><![CDATA[testCookieSameSiteDefaultsToIniSettings]]></code>
       <code><![CDATA[testCookieSameSiteIsMutable]]></code>
     </MissingReturnType>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->config]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference>
-      <code><![CDATA[getCacheExpire]]></code>
-      <code><![CDATA[getCacheLimiter]]></code>
-      <code><![CDATA[getCookieDomain]]></code>
-      <code><![CDATA[getCookieHttpOnly]]></code>
-      <code><![CDATA[getCookieLifetime]]></code>
-      <code><![CDATA[getCookiePath]]></code>
-      <code><![CDATA[getCookieSameSite]]></code>
-      <code><![CDATA[getCookieSecure]]></code>
-      <code><![CDATA[getGcDivisor]]></code>
-      <code><![CDATA[getGcMaxlifetime]]></code>
-      <code><![CDATA[getGcProbability]]></code>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getRefererCheck]]></code>
-      <code><![CDATA[getRememberMeSeconds]]></code>
-      <code><![CDATA[getSaveHandler]]></code>
-      <code><![CDATA[getSavePath]]></code>
-      <code><![CDATA[getSerializeHandler]]></code>
-      <code><![CDATA[getSidBitsPerCharacter]]></code>
-      <code><![CDATA[getSidLength]]></code>
-      <code><![CDATA[getUrlRewriterTags]]></code>
-      <code><![CDATA[getUseCookies]]></code>
-      <code><![CDATA[getUseOnlyCookies]]></code>
-      <code><![CDATA[getUseTransSid]]></code>
-      <code><![CDATA[setCacheExpire]]></code>
-      <code><![CDATA[setCacheExpire]]></code>
-      <code><![CDATA[setCacheExpire]]></code>
-      <code><![CDATA[setCacheLimiter]]></code>
-      <code><![CDATA[setCacheLimiter]]></code>
-      <code><![CDATA[setCacheLimiter]]></code>
-      <code><![CDATA[setCookieDomain]]></code>
-      <code><![CDATA[setCookieDomain]]></code>
-      <code><![CDATA[setCookieDomain]]></code>
-      <code><![CDATA[setCookieDomain]]></code>
-      <code><![CDATA[setCookieHttpOnly]]></code>
-      <code><![CDATA[setCookieHttpOnly]]></code>
-      <code><![CDATA[setCookieLifetime]]></code>
-      <code><![CDATA[setCookieLifetime]]></code>
-      <code><![CDATA[setCookieLifetime]]></code>
-      <code><![CDATA[setCookieLifetime]]></code>
-      <code><![CDATA[setCookiePath]]></code>
-      <code><![CDATA[setCookiePath]]></code>
-      <code><![CDATA[setCookiePath]]></code>
-      <code><![CDATA[setCookiePath]]></code>
-      <code><![CDATA[setCookiePath]]></code>
-      <code><![CDATA[setCookieSameSite]]></code>
-      <code><![CDATA[setCookieSameSite]]></code>
-      <code><![CDATA[setCookieSecure]]></code>
-      <code><![CDATA[setCookieSecure]]></code>
-      <code><![CDATA[setGcDivisor]]></code>
-      <code><![CDATA[setGcDivisor]]></code>
-      <code><![CDATA[setGcDivisor]]></code>
-      <code><![CDATA[setGcMaxlifetime]]></code>
-      <code><![CDATA[setGcMaxlifetime]]></code>
-      <code><![CDATA[setGcMaxlifetime]]></code>
-      <code><![CDATA[setGcProbability]]></code>
-      <code><![CDATA[setGcProbability]]></code>
-      <code><![CDATA[setGcProbability]]></code>
-      <code><![CDATA[setGcProbability]]></code>
-      <code><![CDATA[setName]]></code>
-      <code><![CDATA[setName]]></code>
-      <code><![CDATA[setName]]></code>
-      <code><![CDATA[setName]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOption]]></code>
-      <code><![CDATA[setOptions]]></code>
-      <code><![CDATA[setPhpSaveHandler]]></code>
-      <code><![CDATA[setPhpSaveHandler]]></code>
-      <code><![CDATA[setPhpSaveHandler]]></code>
-      <code><![CDATA[setPhpSaveHandler]]></code>
-      <code><![CDATA[setPhpSaveHandler]]></code>
-      <code><![CDATA[setPhpSaveHandler]]></code>
-      <code><![CDATA[setRememberMeSeconds]]></code>
-      <code><![CDATA[setSaveHandler]]></code>
-      <code><![CDATA[setSaveHandler]]></code>
-      <code><![CDATA[setSavePath]]></code>
-      <code><![CDATA[setSavePath]]></code>
-      <code><![CDATA[setSavePath]]></code>
-      <code><![CDATA[setSerializeHandler]]></code>
-      <code><![CDATA[setSerializeHandler]]></code>
-      <code><![CDATA[setSerializeHandler]]></code>
-      <code><![CDATA[setSidBitsPerCharacter]]></code>
-      <code><![CDATA[setSidBitsPerCharacter]]></code>
-      <code><![CDATA[setSidBitsPerCharacter]]></code>
-      <code><![CDATA[setSidBitsPerCharacter]]></code>
-      <code><![CDATA[setSidLength]]></code>
-      <code><![CDATA[setSidLength]]></code>
-      <code><![CDATA[setSidLength]]></code>
-      <code><![CDATA[setStorageOption]]></code>
-      <code><![CDATA[setStorageOption]]></code>
-      <code><![CDATA[setStorageOption]]></code>
-      <code><![CDATA[setUrlRewriterTags]]></code>
-      <code><![CDATA[setUrlRewriterTags]]></code>
-      <code><![CDATA[setUseCookies]]></code>
-      <code><![CDATA[setUseCookies]]></code>
-    </PossiblyNullReference>
     <PossiblyUnusedMethod>
       <code><![CDATA[optionsProvider]]></code>
       <code><![CDATA[sidSidPerCharacters]]></code>
@@ -867,32 +739,12 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="test/TestAsset/TestManager.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[void]]></code>
-      <code><![CDATA[void]]></code>
-      <code><![CDATA[void]]></code>
-    </ImplementedReturnTypeMismatch>
-    <InvalidReturnType>
-      <code><![CDATA[forgetMe]]></code>
-      <code><![CDATA[getId]]></code>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getValidatorChain]]></code>
-      <code><![CDATA[isValid]]></code>
-      <code><![CDATA[regenerateId]]></code>
-      <code><![CDATA[sessionExists]]></code>
-      <code><![CDATA[setValidatorChain]]></code>
-    </InvalidReturnType>
     <PossiblyUnusedMethod>
       <code><![CDATA[stop]]></code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedProperty>
-      <code><![CDATA[$configDefaultClass]]></code>
       <code><![CDATA[$started]]></code>
-      <code><![CDATA[$storageDefaultClass]]></code>
     </PossiblyUnusedProperty>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[TestManager]]></code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/TestSaveHandler.php">
     <ImplementedParamTypeMismatch>

--- a/src/AbstractManager.php
+++ b/src/AbstractManager.php
@@ -10,6 +10,7 @@ use Laminas\Session\ManagerInterface as Manager;
 use Laminas\Session\SaveHandler\SaveHandlerInterface as SaveHandler;
 use Laminas\Session\Storage\SessionArrayStorage;
 use Laminas\Session\Storage\StorageInterface as Storage;
+use Laminas\Session\Validator\ValidatorInterface;
 
 use function class_exists;
 use function sprintf;
@@ -21,28 +22,21 @@ use function sprintf;
  */
 abstract class AbstractManager implements Manager
 {
-    /** @var Config */
-    protected $config;
+    protected Config $config;
 
     /**
      * Default configuration class to use when no configuration provided
-     *
-     * @var string
      */
-    protected $defaultConfigClass = SessionConfig::class;
+    protected string $defaultConfigClass = SessionConfig::class;
 
-    /** @var Storage */
-    protected $storage;
+    protected Storage $storage;
 
     /**
      * Default storage class to use when no storage provided
-     *
-     * @var string
      */
-    protected $defaultStorageClass = SessionArrayStorage::class;
+    protected string $defaultStorageClass = SessionArrayStorage::class;
 
-    /** @var SaveHandler */
-    protected $saveHandler;
+    protected SaveHandler|null $saveHandler = null;
 
     /**
      * Constructor
@@ -53,6 +47,7 @@ abstract class AbstractManager implements Manager
         ?Config $config = null,
         ?Storage $storage = null,
         ?SaveHandler $saveHandler = null,
+        /** @var list<class-string<ValidatorInterface>> */
         protected array $validators = []
     ) {
         // init config
@@ -107,10 +102,8 @@ abstract class AbstractManager implements Manager
 
     /**
      * Set configuration object
-     *
-     * @return AbstractManager
      */
-    public function setConfig(Config $config)
+    public function setConfig(Config $config): static
     {
         $this->config = $config;
         return $this;
@@ -118,20 +111,16 @@ abstract class AbstractManager implements Manager
 
     /**
      * Retrieve configuration object
-     *
-     * @return Config
      */
-    public function getConfig()
+    public function getConfig(): Config
     {
         return $this->config;
     }
 
     /**
      * Set session storage object
-     *
-     * @return AbstractManager
      */
-    public function setStorage(Storage $storage)
+    public function setStorage(Storage $storage): static
     {
         $this->storage = $storage;
         return $this;
@@ -139,20 +128,16 @@ abstract class AbstractManager implements Manager
 
     /**
      * Retrieve storage object
-     *
-     * @return Storage
      */
-    public function getStorage()
+    public function getStorage(): Storage
     {
         return $this->storage;
     }
 
     /**
      * Set session save handler object
-     *
-     * @return AbstractManager
      */
-    public function setSaveHandler(SaveHandler $saveHandler)
+    public function setSaveHandler(SaveHandler $saveHandler): static
     {
         $this->saveHandler = $saveHandler;
         return $this;
@@ -160,10 +145,8 @@ abstract class AbstractManager implements Manager
 
     /**
      * Get SaveHandler Object
-     *
-     * @return SaveHandler
      */
-    public function getSaveHandler()
+    public function getSaveHandler(): SaveHandler|null
     {
         return $this->saveHandler;
     }

--- a/src/ManagerInterface.php
+++ b/src/ManagerInterface.php
@@ -14,75 +14,45 @@ use Laminas\Session\Storage\StorageInterface as Storage;
  */
 interface ManagerInterface
 {
-    /** @return self */
-    public function setConfig(Config $config);
+    public function setConfig(Config $config): static;
 
-    /** @return Config */
-    public function getConfig();
+    public function getConfig(): Config;
 
-    /** @return self */
-    public function setStorage(Storage $storage);
+    public function setStorage(Storage $storage): static;
 
-    /** @return Storage */
-    public function getStorage();
+    public function getStorage(): Storage;
 
-    /** @return self */
-    public function setSaveHandler(SaveHandler $saveHandler);
+    public function setSaveHandler(SaveHandler $saveHandler): static;
 
-    /** @return SaveHandler */
-    public function getSaveHandler();
+    public function getSaveHandler(): SaveHandler|null;
 
-    /** @return bool */
-    public function sessionExists();
+    public function sessionExists(): bool;
 
-    /** @return void */
-    public function start();
+    public function start(): void;
 
-    /** @return void */
-    public function destroy();
+    public function destroy(): void;
 
-    /** @return void */
-    public function writeClose();
+    public function writeClose(): void;
 
-    /**
-     * @param string $name
-     * @return self
-     */
-    public function setName($name);
+    public function setName(string $name): static;
 
-    /** @return string */
-    public function getName();
+    public function getName(): string;
 
-    /**
-     * @param int|string $id
-     * @return self
-     */
-    public function setId($id);
+    public function setId(string $id): static;
 
-    /** @return int|string */
-    public function getId();
+    public function getId(): string;
 
-    /** @return self */
-    public function regenerateId();
+    public function regenerateId(): static;
 
-    /**
-     * @param null|int $ttl
-     * @return self
-     */
-    public function rememberMe($ttl = null);
+    public function rememberMe(int|null $ttl = null): static;
 
-    /** @return self */
-    public function forgetMe();
+    public function forgetMe(): static;
 
-    /** @return void */
-    public function expireSessionCookie();
+    public function expireSessionCookie(): void;
 
-    /** @return self */
-    public function setValidatorChain(EventManagerInterface $chain);
+    public function setValidatorChain(EventManagerInterface $chain): static;
 
-    /** @return EventManagerInterface */
-    public function getValidatorChain();
+    public function getValidatorChain(): EventManagerInterface;
 
-    /** @return bool */
-    public function isValid();
+    public function isValid(): bool;
 }

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -6,7 +6,6 @@ namespace Laminas\Session;
 
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerInterface;
-use Laminas\Session\Validator\ValidatorInterface;
 use Laminas\Session\Validator\Environment;
 use Laminas\Session\Validator\ValidatorInterface;
 use Traversable;
@@ -170,9 +169,6 @@ final class SessionManager extends AbstractManager
         /** @var array<string, mixed> $storage */
         $storage = $this->getStorage()->getMetadata();
 
-        /**
-         * @var class-string<ValidatorInterface> $validatorName
-         */
         foreach ($this->validators as $validatorName) {
             $validatorValues = $this->getStorage()->getMetadata('_VALID');
             if (is_array($validatorValues) && array_key_exists($validatorName, $validatorValues)) {

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -6,6 +6,7 @@ namespace Laminas\Session;
 
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerInterface;
+use Laminas\Session\Validator\ValidatorInterface;
 use Laminas\Session\Validator\Environment;
 use Laminas\Session\Validator\ValidatorInterface;
 use Traversable;
@@ -35,42 +36,38 @@ use const PHP_SESSION_ACTIVE;
 
 /**
  * Session ManagerInterface implementation utilizing ext/session
+ *
+ * @psalm-type OptionsArgument = array{
+ *     preserve_storage?: bool,
+ *     send_expire_cookie?: bool,
+ *     clear_storage?: bool,
+ *     attach_default_validators?: bool
+ * }
  */
-class SessionManager extends AbstractManager
+final class SessionManager extends AbstractManager
 {
-    /**
-     * Default options when a call to {@link destroy()} is made
-     * - send_expire_cookie: whether or not to send a cookie expiring the current session cookie
-     * - clear_storage: whether or not to empty the storage object of any stored values
-     *
-     * @var array
-     */
-    protected $defaultDestroyOptions = [
-        'send_expire_cookie' => true,
-        'clear_storage'      => false,
-    ];
+    private bool $preserveStorage;
+    private bool $sendExpireCookie;
+    private bool $clearStorage;
 
-    /** @var array Default session manager options */
-    protected $defaultOptions = [
-        'attach_default_validators' => true,
-    ];
-
-    /** @var array Default validators */
-    protected $defaultValidators = [
+    /** @var list<class-string<ValidatorInterface>> $defaultValidators */
+    protected array $defaultValidators = [
         Validator\Id::class,
     ];
 
-    /** @var string value returned by session_name() */
-    protected $name;
+    /** value returned by session_name() */
+    protected string|null $name = null;
 
-    /** @var EventManagerInterface Validation chain to determine if session is valid */
-    protected $validatorChain;
+    /** Validation chain to determine if session is valid */
+    protected EventManagerInterface|null $validatorChain = null;
 
     protected array $options = [];
 
     /**
      * Constructor
      *
+     * @param list<class-string<ValidatorInterface>> $validators
+     * @param OptionsArgument $options
      * @throws Exception\RuntimeException
      */
     public function __construct(
@@ -80,23 +77,24 @@ class SessionManager extends AbstractManager
         array $validators = [],
         array $options = []
     ) {
-        $options = array_merge($this->defaultOptions, $options);
-        if ($options['attach_default_validators']) {
+        $this->preserveStorage  = $options['preserve_storage'] ?? false;
+        $this->sendExpireCookie = $options['send_expire_cookie'] ?? true;
+        $this->clearStorage     = $options['clear_storage'] ?? false;
+
+        if ($options['attach_default_validators'] ?? true) {
             $validators = array_merge($this->defaultValidators, $validators);
         }
 
         $this->options = $options;
 
         parent::__construct($config, $storage, $saveHandler, $validators);
-        register_shutdown_function([$this, 'writeClose']);
+        register_shutdown_function($this->writeClose(...));
     }
 
     /**
      * Does a session exist and is it currently active?
-     *
-     * @return bool
      */
-    public function sessionExists()
+    public function sessionExists(): bool
     {
         return session_status() === PHP_SESSION_ACTIVE || headers_sent();
     }
@@ -108,12 +106,9 @@ class SessionManager extends AbstractManager
      * {@link isValid()} once session_start() is called, and raises an
      * exception if validation fails.
      *
-     * @param bool $preserveStorage        If set to true, current session storage will not be overwritten by the
-     *                                     contents of $_SESSION.
-     * @return void
      * @throws Exception\RuntimeException
      */
-    public function start($preserveStorage = false)
+    public function start(bool|null $preserveStorage = null): void
     {
         if ($this->sessionExists()) {
             return;
@@ -147,6 +142,8 @@ class SessionManager extends AbstractManager
 
         $storage = $this->getStorage();
 
+        $preserveStorage = $preserveStorage ?? $this->preserveStorage;
+
         // Since session is starting, we need to potentially repopulate our
         // session storage
         if ($storage instanceof Storage\SessionStorage) {
@@ -168,7 +165,7 @@ class SessionManager extends AbstractManager
     /**
      * Create validators, insert reference value and add them to the validator chain
      */
-    protected function initializeValidatorChain()
+    protected function initializeValidatorChain(): void
     {
         /** @var array<string, mixed> $storage */
         $storage = $this->getStorage()->getMetadata();
@@ -203,10 +200,9 @@ class SessionManager extends AbstractManager
     /**
      * Destroy/end a session
      *
-     * @param  array $options See {@link $defaultDestroyOptions}
-     * @return void
+     * @param OptionsArgument|null $options
      */
-    public function destroy(?array $options = null)
+    public function destroy(?array $options = null): void
     {
         // session_destroy() requires active session while method
         // $this->sessionExists() includes other conditions
@@ -214,18 +210,15 @@ class SessionManager extends AbstractManager
             return;
         }
 
-        if (null === $options) {
-            $options = $this->defaultDestroyOptions;
-        } else {
-            $options = array_merge($this->defaultDestroyOptions, $options);
-        }
+        $sendExpireCookie = $options['send_expire_cookie'] ?? $this->sendExpireCookie;
+        $clearStorage     = $options['clear_storage'] ?? $this->clearStorage;
 
         session_destroy();
-        if (! headers_sent() && $options['send_expire_cookie']) {
+        if (! headers_sent() && $sendExpireCookie) {
             $this->expireSessionCookie();
         }
 
-        if ($options['clear_storage']) {
+        if ($clearStorage) {
             $this->getStorage()->clear();
         }
     }
@@ -234,10 +227,8 @@ class SessionManager extends AbstractManager
      * Write session to save handler and close
      *
      * Once done, the Storage object will be marked as isImmutable.
-     *
-     * @return void
      */
-    public function writeClose()
+    public function writeClose(): void
     {
         // The assumption is that we're using PHP's ext/session.
         // session_write_close() will actually overwrite $_SESSION with an
@@ -265,11 +256,9 @@ class SessionManager extends AbstractManager
      * If the session has already been started, or if the name provided fails
      * validation, an exception will be raised.
      *
-     * @param  string $name
-     * @return SessionManager
      * @throws Exception\InvalidArgumentException
      */
-    public function setName($name)
+    public function setName(string $name): static
     {
         if ($this->sessionExists()) {
             throw new Exception\InvalidArgumentException(
@@ -292,10 +281,8 @@ class SessionManager extends AbstractManager
      * Get session name
      *
      * Proxies to {@link session_name()}.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         if (null === $this->name) {
             // If we're grabbing via session_name(), we don't need our
@@ -311,11 +298,8 @@ class SessionManager extends AbstractManager
      * Set session ID
      *
      * Can safely be called in the middle of a session.
-     *
-     * @param  string $id
-     * @return SessionManager
      */
-    public function setId($id)
+    public function setId(string $id): static
     {
         if ($this->sessionExists()) {
             throw new Exception\RuntimeException(
@@ -330,10 +314,8 @@ class SessionManager extends AbstractManager
      * Get session ID
      *
      * Proxies to {@link session_id()}
-     *
-     * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return session_id();
     }
@@ -343,14 +325,11 @@ class SessionManager extends AbstractManager
      *
      * Regenerate the session ID, using session save handler's
      * native ID generation Can safely be called in the middle of a session.
-     *
-     * @param  bool $deleteOldSession
-     * @return SessionManager
      */
-    public function regenerateId($deleteOldSession = true)
+    public function regenerateId(bool $deleteOldSession = true): static
     {
         if ($this->sessionExists()) {
-            session_regenerate_id((bool) $deleteOldSession);
+            session_regenerate_id($deleteOldSession);
         }
 
         return $this;
@@ -360,11 +339,8 @@ class SessionManager extends AbstractManager
      * Set the TTL (in seconds) for the session cookie expiry
      *
      * Can safely be called in the middle of a session.
-     *
-     * @param  null|int $ttl
-     * @return SessionManager
      */
-    public function rememberMe($ttl = null)
+    public function rememberMe(int|null $ttl = null): static
     {
         if (null === $ttl) {
             $ttl = $this->getConfig()->getRememberMeSeconds();
@@ -377,10 +353,8 @@ class SessionManager extends AbstractManager
      * Set a 0s TTL for the session cookie
      *
      * Can safely be called in the middle of a session.
-     *
-     * @return SessionManager
      */
-    public function forgetMe()
+    public function forgetMe(): static
     {
         $this->setSessionCookieLifetime(0);
         return $this;
@@ -390,10 +364,8 @@ class SessionManager extends AbstractManager
      * Set the validator chain to use when validating a session
      *
      * In most cases, you should use an instance of {@link ValidatorChain}.
-     *
-     * @return SessionManager
      */
-    public function setValidatorChain(EventManagerInterface $chain)
+    public function setValidatorChain(EventManagerInterface $chain): static
     {
         $this->validatorChain = $chain;
         return $this;
@@ -403,13 +375,12 @@ class SessionManager extends AbstractManager
      * Get the validator chain to use when validating a session
      *
      * By default, uses an instance of {@link ValidatorChain}.
-     *
-     * @return EventManagerInterface
      */
-    public function getValidatorChain()
+    public function getValidatorChain(): EventManagerInterface
     {
         if (null === $this->validatorChain) {
             $this->setValidatorChain(new ValidatorChain($this->getStorage()));
+            assert($this->validatorChain instanceof EventManagerInterface);
         }
         return $this->validatorChain;
     }
@@ -419,10 +390,8 @@ class SessionManager extends AbstractManager
      *
      * Notifies the Validator Chain until either all validators have returned
      * true or one has failed.
-     *
-     * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         $validator = $this->getValidatorChain();
         $event     = new Event();
@@ -434,23 +403,15 @@ class SessionManager extends AbstractManager
 
         $responses = $validator->triggerEventUntil($falseResult, $event);
 
-        if ($responses->stopped()) {
-            // If execution was halted, validation failed
-            return false;
-        }
-
-        // Otherwise, we're good to go
-        return true;
+        return ! $responses->stopped();
     }
 
     /**
      * Expire the session cookie
      *
      * Sends a session cookie with no value, and with an expiry in the past.
-     *
-     * @return void
      */
-    public function expireSessionCookie()
+    public function expireSessionCookie(): void
     {
         $config = $this->getConfig();
         if (! $config->getUseCookies()) {
@@ -472,11 +433,8 @@ class SessionManager extends AbstractManager
      *
      * If a session already exists, destroys it (without sending an expiration
      * cookie), regenerates the session ID, and restarts the session.
-     *
-     * @param  int $ttl
-     * @return void
      */
-    protected function setSessionCookieLifetime($ttl)
+    private function setSessionCookieLifetime(int $ttl): void
     {
         $config = $this->getConfig();
         if (! $config->getUseCookies()) {
@@ -497,10 +455,8 @@ class SessionManager extends AbstractManager
      *
      * Since ext/session is coupled to this particular session manager
      * register the save handler with ext/session.
-     *
-     * @return bool
      */
-    protected function registerSaveHandler(SaveHandler\SaveHandlerInterface $saveHandler)
+    private function registerSaveHandler(SaveHandler\SaveHandlerInterface $saveHandler): bool
     {
         return session_set_save_handler($saveHandler);
     }

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -32,7 +32,7 @@ use const E_USER_DEPRECATED;
  */
 class SessionConfigTest extends TestCase
 {
-    protected SessionConfig|null $config = null;
+    protected SessionConfig $config;
 
     protected function setUp(): void
     {
@@ -43,7 +43,6 @@ class SessionConfigTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->config                     = null;
         SessionConfig::$phpinfo           = 'phpinfo';
         SessionConfig::$sessionModuleName = 'session_module_name';
     }
@@ -901,6 +900,9 @@ class SessionConfigTest extends TestCase
 
     public function testProvidingNonSessionHandlerToSetPhpSaveHandlerResultsInException(): void
     {
+        $r = new ReflectionProperty($this->config, 'knownSaveHandlers');
+        $r->setValue($this->config, ['files']);
+
         $handler = new stdClass();
 
         $this->expectException(Exception\InvalidArgumentException::class);

--- a/test/SessionArrayStorageTest.php
+++ b/test/SessionArrayStorageTest.php
@@ -8,6 +8,7 @@ use Laminas\Session\Container;
 use Laminas\Session\SessionManager;
 use Laminas\Session\Storage\SessionArrayStorage;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 use function var_export;
@@ -161,10 +162,8 @@ class SessionArrayStorageTest extends TestCase
         self::assertSame($expected, $this->storage->toArray(true));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     #[IgnoreDeprecations]
+    #[RunInSeparateProcess]
     public function testExpirationHops(): void
     {
         // since we cannot explicitly test reinitializing the session

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -19,7 +19,6 @@ use Laminas\Session\Validator\Id;
 use Laminas\Session\Validator\RemoteAddr;
 use LaminasTest\Session\TestAsset\Php81CompatibleStorageInterface;
 use LaminasTest\Session\TestAsset\TestFailingValidator;
-use LaminasTest\Session\Validator\StaticValidatorStub;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -127,7 +126,7 @@ class SessionManagerTest extends TestCase
     public function testCanPassValidatorsToConstructor(): void
     {
         $validators = [
-            StaticValidatorStub::class,
+            TestFailingValidator::class,
         ];
         $manager    = new SessionManager(null, null, null, $validators);
         foreach ($validators as $validator) {
@@ -147,7 +146,7 @@ class SessionManagerTest extends TestCase
             Id::class,
         ];
         $validators        = [
-            StaticValidatorStub::class,
+            TestFailingValidator::class,
         ];
         $manager           = new SessionManager(null, null, null, $validators);
         $this->assertAttributeEquals(array_merge($defaultValidators, $validators), 'validators', $manager);

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -19,6 +19,7 @@ use Laminas\Session\Validator\Id;
 use Laminas\Session\Validator\RemoteAddr;
 use LaminasTest\Session\TestAsset\Php81CompatibleStorageInterface;
 use LaminasTest\Session\TestAsset\TestFailingValidator;
+use LaminasTest\Session\Validator\StaticValidatorStub;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -126,8 +127,7 @@ class SessionManagerTest extends TestCase
     public function testCanPassValidatorsToConstructor(): void
     {
         $validators = [
-            'foo',
-            'bar',
+            StaticValidatorStub::class,
         ];
         $manager    = new SessionManager(null, null, null, $validators);
         foreach ($validators as $validator) {
@@ -147,8 +147,7 @@ class SessionManagerTest extends TestCase
             Id::class,
         ];
         $validators        = [
-            'foo',
-            'bar',
+            StaticValidatorStub::class,
         ];
         $manager           = new SessionManager(null, null, null, $validators);
         $this->assertAttributeEquals(array_merge($defaultValidators, $validators), 'validators', $manager);
@@ -413,11 +412,19 @@ class SessionManagerTest extends TestCase
             self::markTestSkipped('Xdebug required for this test');
         }
 
-        $this->manager = new SessionManager();
+        $this->manager = new SessionManager(
+            null,
+            null,
+            null,
+            [],
+            [
+                'send_expire_cookie' => false,
+            ]
+        );
         $config        = $this->manager->getConfig();
         $config->setUseCookies(true);
         $this->manager->start();
-        $this->manager->destroy(['send_expire_cookie' => false]);
+        $this->manager->destroy();
 
         echo '';
 
@@ -458,11 +465,19 @@ class SessionManagerTest extends TestCase
     #[IgnoreDeprecations]
     public function testPassingClearStorageOptionWhenCallingDestroyClearsStorage(): void
     {
-        $this->manager = new SessionManager();
+        $this->manager = new SessionManager(
+            null,
+            null,
+            null,
+            [],
+            [
+                'clear_storage' => true,
+            ]
+        );
         $this->manager->start();
         $storage        = $this->manager->getStorage();
         $storage['foo'] = 'bar';
-        $this->manager->destroy(['clear_storage' => true]);
+        $this->manager->destroy();
         self::assertFalse(isset($storage['foo']));
     }
 
@@ -470,13 +485,21 @@ class SessionManagerTest extends TestCase
     #[IgnoreDeprecations]
     public function testDestroySessionWhenHeadersHaveBeenSent(): void
     {
-        $this->manager = new SessionManager();
+        $this->manager = new SessionManager(
+            null,
+            null,
+            null,
+            [],
+            [
+                'clear_storage' => true,
+            ]
+        );
         $this->manager->start();
         $storage        = $this->manager->getStorage();
         $storage['foo'] = 'bar';
         echo ' ';
         ob_flush();
-        $this->manager->destroy(['clear_storage' => true]);
+        $this->manager->destroy();
         self::assertFalse(isset($storage['foo']));
     }
 

--- a/test/TestAsset/TestManager.php
+++ b/test/TestAsset/TestManager.php
@@ -6,34 +6,24 @@ namespace LaminasTest\Session\TestAsset;
 
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Session\AbstractManager;
-use Laminas\Session\Config\ConfigInterface;
 use Laminas\Session\Config\StandardConfig;
 use Laminas\Session\Storage\ArrayStorage;
-use Laminas\Session\Storage\StorageInterface;
+use Laminas\Session\ValidatorChain;
 
-class TestManager extends AbstractManager
+final class TestManager extends AbstractManager
 {
-    /** @var bool */
-    public $started = false;
+    public bool $started = false;
 
-    /**
-     * @var string
-     * @psalm-var class-string<ConfigInterface>
-     */
-    protected $configDefaultClass = StandardConfig::class;
+    protected string $defaultConfigClass = StandardConfig::class;
 
-    /**
-     * @var string
-     * @psalm-var class-string<StorageInterface>
-     */
-    protected $storageDefaultClass = ArrayStorage::class;
+    protected string $defaultStorageClass = ArrayStorage::class;
 
-    public function start()
+    public function start(): void
     {
         $this->started = true;
     }
 
-    public function destroy()
+    public function destroy(): void
     {
         $this->started = false;
     }
@@ -42,68 +32,67 @@ class TestManager extends AbstractManager
     {
     }
 
-    public function writeClose()
+    public function writeClose(): void
     {
         $this->started = false;
     }
 
-    public function getName()
+    public function getName(): string
     {
+        return self::class;
     }
 
-    /**
-     * @param string $name
-     * @return void
-     */
-    public function setName($name)
+    public function setName(string $name): static
     {
+        return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
+        return 'TestManagerId';
     }
 
-    /**
-     * @param string|int $id
-     * @return void
-     */
-    public function setId($id)
+    public function setId(string $id): static
     {
+        return $this;
     }
 
-    public function regenerateId()
+    public function regenerateId(): static
     {
+        return $this;
     }
 
-    /**
-     * @param null|int $ttl
-     * @return void
-     */
-    public function rememberMe($ttl = null)
+    public function rememberMe(int|null $ttl = null): static
     {
+        return $this;
     }
 
-    public function forgetMe()
+    public function forgetMe(): static
     {
+        return $this;
     }
 
-    public function setValidatorChain(EventManagerInterface $chain)
+    public function setValidatorChain(EventManagerInterface $chain): static
     {
+        return $this;
     }
 
-    public function getValidatorChain()
+    public function getValidatorChain(): EventManagerInterface
     {
+        return new ValidatorChain($this->getStorage());
     }
 
-    public function isValid()
+    public function isValid(): bool
     {
+        return true;
     }
 
-    public function sessionExists()
+    public function sessionExists(): bool
     {
+        return true;
     }
 
-    public function expireSessionCookie()
+    public function expireSessionCookie(): void
     {
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes

### Description

Based on issue #113 and continuing the PR #135 - added native method and return types to the "ManagerInterface" only, to keep it easier to review.

There was also a small change in the option parsing logic for the SessionManager:
- The `setId()` method now only accepts `string` type instead of the previous `int|string` union type
- Options like `send_expire_cookie`, `clear_storage` and `preserve_storage` could be set during construction and will be used in `destroy()` and `start()` method calls if the parameter will be passed as null.