### PR TITLE
Allow custom environment objects

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -663,6 +663,8 @@
       <code><![CDATA[$_SESSION[$key]]]></code>
       <code><![CDATA[$_SESSION[$key]]]></code>
       <code><![CDATA[$_SESSION['__Laminas']['_VALID']]]></code>
+      <code><![CDATA[$_SESSION['__Laminas']['_VALID']]]></code>
+      <code><![CDATA[$_SESSION['__Laminas']['environment']]]></code>
       <code><![CDATA[$_SESSION['__Laminas']['environment']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -210,6 +210,7 @@
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$configService]]></code>
+      <code><![CDATA[$environmentFactory]]></code>
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$saveHandler]]></code>
       <code><![CDATA[$storage]]></code>
@@ -250,6 +251,9 @@
     <TypeDoesNotContainType>
       <code><![CDATA[$oldSessionData instanceof Traversable]]></code>
     </TypeDoesNotContainType>
+    <UnusedProperty>
+      <code><![CDATA[$defaultValidators]]></code>
+    </UnusedProperty>
     <UnusedReturnValue>
       <code><![CDATA[bool]]></code>
     </UnusedReturnValue>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,6 +6,8 @@ namespace Laminas\Session;
 
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Session\Service\EnvironmentFactory;
+use Laminas\Session\Service\EnvironmentFactoryInterface;
 
 /** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
 final class ConfigProvider
@@ -35,7 +37,8 @@ final class ConfigProvider
                 Service\ContainerAbstractServiceFactory::class,
             ],
             'aliases'            => [
-                SessionManager::class => ManagerInterface::class,
+                SessionManager::class              => ManagerInterface::class,
+                EnvironmentFactoryInterface::class => EnvironmentFactory::class,
 
                 // Legacy Zend Framework aliases
                 'Zend\Session\SessionManager'           => SessionManager::class,
@@ -47,6 +50,7 @@ final class ConfigProvider
                 Config\ConfigInterface::class   => Service\SessionConfigFactory::class,
                 ManagerInterface::class         => Service\SessionManagerFactory::class,
                 Storage\StorageInterface::class => Service\StorageFactory::class,
+                EnvironmentFactory::class       => InvokableFactory::class,
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,8 +6,8 @@ namespace Laminas\Session;
 
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Session\Service\EnvironmentFactory;
 use Laminas\Session\Service\EnvironmentFactoryInterface;
+use Laminas\Session\Service\GlobalEnvironmentFactory;
 
 /** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
 final class ConfigProvider
@@ -38,7 +38,7 @@ final class ConfigProvider
             ],
             'aliases'            => [
                 SessionManager::class              => ManagerInterface::class,
-                EnvironmentFactoryInterface::class => EnvironmentFactory::class,
+                EnvironmentFactoryInterface::class => GlobalEnvironmentFactory::class,
 
                 // Legacy Zend Framework aliases
                 'Zend\Session\SessionManager'           => SessionManager::class,
@@ -50,7 +50,7 @@ final class ConfigProvider
                 Config\ConfigInterface::class   => Service\SessionConfigFactory::class,
                 ManagerInterface::class         => Service\SessionManagerFactory::class,
                 Storage\StorageInterface::class => Service\StorageFactory::class,
-                EnvironmentFactory::class       => InvokableFactory::class,
+                GlobalEnvironmentFactory::class => InvokableFactory::class,
             ],
         ];
     }

--- a/src/Service/EnvironmentFactory.php
+++ b/src/Service/EnvironmentFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Session\Service;
+
+use Laminas\Session\Validator\Environment;
+use Laminas\Session\Validator\EnvironmentInterface;
+
+final class EnvironmentFactory implements EnvironmentFactoryInterface
+{
+    public function getEnvironment(): EnvironmentInterface
+    {
+        return Environment::fromGlobals($_SERVER);
+    }
+}

--- a/src/Service/EnvironmentFactoryInterface.php
+++ b/src/Service/EnvironmentFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Session\Service;
+
+use Laminas\Session\Validator\EnvironmentInterface;
+
+interface EnvironmentFactoryInterface
+{
+    public function getEnvironment(): EnvironmentInterface;
+}

--- a/src/Service/EnvironmentFactoryInterface.php
+++ b/src/Service/EnvironmentFactoryInterface.php
@@ -6,7 +6,12 @@ namespace Laminas\Session\Service;
 
 use Laminas\Session\Validator\EnvironmentInterface;
 
+/**
+ * Allows users to override the default {@see GlobalEnvironmentFactory} in DI
+ * in order to return custom {@see Environment} implementations
+ */
 interface EnvironmentFactoryInterface
 {
+    /** Retrieve an instance of {@see EnvironmentInterface} based on the configured factory */
     public function getEnvironment(): EnvironmentInterface;
 }

--- a/src/Service/GlobalEnvironmentFactory.php
+++ b/src/Service/GlobalEnvironmentFactory.php
@@ -7,8 +7,9 @@ namespace Laminas\Session\Service;
 use Laminas\Session\Validator\Environment;
 use Laminas\Session\Validator\EnvironmentInterface;
 
-final class EnvironmentFactory implements EnvironmentFactoryInterface
+final class GlobalEnvironmentFactory implements EnvironmentFactoryInterface
 {
+    /** Retrieves instance of {@see Environment} generated from the $_SERVER superglobal */
     public function getEnvironment(): EnvironmentInterface
     {
         return Environment::fromGlobals($_SERVER);

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -14,12 +14,14 @@ use Laminas\Session\ManagerInterface;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\SessionManager;
 use Laminas\Session\Storage\StorageInterface;
+use Laminas\Session\Validator\EnvironmentInterface;
 use Psr\Container\ContainerInterface;
 
 use function array_merge;
 use function class_exists;
 use function get_debug_type;
 use function is_array;
+use function is_string;
 use function is_subclass_of;
 use function sprintf;
 
@@ -106,6 +108,8 @@ final class SessionManagerFactory implements FactoryInterface
             }
         }
 
+        $environmentClass = null;
+
         // Get session manager configuration, if any, and merge with default configuration
         if ($container->has('config')) {
             $configService = $container->get('config');
@@ -123,7 +127,16 @@ final class SessionManagerFactory implements FactoryInterface
             if (isset($managerConfig['options'])) {
                 $options = $managerConfig['options'];
             }
+
+            if (
+                isset($managerConfig['environment'])
+                && is_string($managerConfig['environment'])
+                && is_subclass_of($managerConfig['environment'], EnvironmentInterface::class)
+            ) {
+                $environmentClass = $managerConfig['environment'];
+            }
         }
+
         $managerClass = class_exists($requestedName) ? $requestedName : SessionManager::class;
         if (! is_subclass_of($managerClass, ManagerInterface::class)) {
             throw new ServiceNotCreatedException(sprintf(
@@ -133,7 +146,7 @@ final class SessionManagerFactory implements FactoryInterface
             ));
         }
 
-        $manager = new $managerClass($config, $storage, $saveHandler, $validators, $options);
+        $manager = new $managerClass($config, $storage, $saveHandler, $validators, $options, $environmentClass);
 
         // If configuration enables the session manager as the default manager for container
         // instances, do so.

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -14,14 +14,12 @@ use Laminas\Session\ManagerInterface;
 use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\SessionManager;
 use Laminas\Session\Storage\StorageInterface;
-use Laminas\Session\Validator\EnvironmentInterface;
 use Psr\Container\ContainerInterface;
 
 use function array_merge;
 use function class_exists;
 use function get_debug_type;
 use function is_array;
-use function is_string;
 use function is_subclass_of;
 use function sprintf;
 
@@ -65,12 +63,13 @@ final class SessionManagerFactory implements FactoryInterface
         string $requestedName,
         ?array $options = null
     ): ManagerInterface {
-        $config        = null;
-        $storage       = null;
-        $saveHandler   = null;
-        $validators    = [];
-        $managerConfig = $this->defaultManagerConfig;
-        $options       = [];
+        $environmentFactory = null;
+        $config             = null;
+        $storage            = null;
+        $saveHandler        = null;
+        $validators         = [];
+        $managerConfig      = $this->defaultManagerConfig;
+        $options            = [];
 
         if ($container->has(ConfigInterface::class)) {
             $config = $container->get(ConfigInterface::class);
@@ -108,8 +107,6 @@ final class SessionManagerFactory implements FactoryInterface
             }
         }
 
-        $environmentClass = null;
-
         // Get session manager configuration, if any, and merge with default configuration
         if ($container->has('config')) {
             $configService = $container->get('config');
@@ -127,13 +124,17 @@ final class SessionManagerFactory implements FactoryInterface
             if (isset($managerConfig['options'])) {
                 $options = $managerConfig['options'];
             }
+        }
 
-            if (
-                isset($managerConfig['environment'])
-                && is_string($managerConfig['environment'])
-                && is_subclass_of($managerConfig['environment'], EnvironmentInterface::class)
-            ) {
-                $environmentClass = $managerConfig['environment'];
+        if ($container->has(EnvironmentFactoryInterface::class)) {
+            $environmentFactory = $container->get(EnvironmentFactoryInterface::class);
+            if (! $environmentFactory instanceof EnvironmentFactoryInterface) {
+                throw new ServiceNotCreatedException(sprintf(
+                    'SessionManager requires that the %s service implement %s; received "%s"',
+                    EnvironmentFactoryInterface::class,
+                    EnvironmentFactoryInterface::class,
+                    get_debug_type($environmentFactory)
+                ));
             }
         }
 
@@ -146,7 +147,7 @@ final class SessionManagerFactory implements FactoryInterface
             ));
         }
 
-        $manager = new $managerClass($config, $storage, $saveHandler, $validators, $options, $environmentClass);
+        $manager = new $managerClass($config, $storage, $saveHandler, $validators, $options, $environmentFactory);
 
         // If configuration enables the session manager as the default manager for container
         // instances, do so.

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -6,7 +6,8 @@ namespace Laminas\Session;
 
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerInterface;
-use Laminas\Session\Validator\Environment;
+use Laminas\Session\Service\EnvironmentFactory;
+use Laminas\Session\Service\EnvironmentFactoryInterface;
 use Laminas\Session\Validator\EnvironmentInterface;
 use Laminas\Session\Validator\ValidatorInterface;
 use Traversable;
@@ -17,7 +18,6 @@ use function assert;
 use function headers_sent;
 use function is_array;
 use function is_string;
-use function is_subclass_of;
 use function iterator_to_array;
 use function preg_match;
 use function register_shutdown_function;
@@ -52,20 +52,19 @@ final class SessionManager extends AbstractManager
     private bool $clearStorage;
 
     /** @var list<class-string<ValidatorInterface>> $defaultValidators */
-    protected array $defaultValidators = [
+    private array $defaultValidators = [
         Validator\Id::class,
     ];
 
     /** value returned by session_name() */
-    protected string|null $name = null;
+    private string|null $name = null;
 
     /** Validation chain to determine if session is valid */
-    protected EventManagerInterface|null $validatorChain = null;
+    private EventManagerInterface|null $validatorChain = null;
 
-    protected array $options = [];
+    private array $options = [];
 
-    /** @var class-string<EnvironmentInterface> */
-    protected string $environmentClass = Environment::class;
+    private EnvironmentFactoryInterface $environmentFactory;
 
     /**
      * Constructor
@@ -80,18 +79,15 @@ final class SessionManager extends AbstractManager
         ?SaveHandler\SaveHandlerInterface $saveHandler = null,
         array $validators = [],
         array $options = [],
-        ?string $environmentClass = null
+        ?EnvironmentFactoryInterface $environmentFactory = null,
     ) {
-        $this->preserveStorage  = $options['preserve_storage'] ?? false;
-        $this->sendExpireCookie = $options['send_expire_cookie'] ?? true;
-        $this->clearStorage     = $options['clear_storage'] ?? false;
+        $this->preserveStorage    = $options['preserve_storage'] ?? false;
+        $this->sendExpireCookie   = $options['send_expire_cookie'] ?? true;
+        $this->clearStorage       = $options['clear_storage'] ?? false;
+        $this->environmentFactory = $environmentFactory ?? new EnvironmentFactory();
 
         if ($options['attach_default_validators'] ?? true) {
             $validators = array_merge($this->defaultValidators, $validators);
-        }
-
-        if (is_string($environmentClass) && is_subclass_of($environmentClass, EnvironmentInterface::class)) {
-            $this->environmentClass = $environmentClass;
         }
 
         $this->options = $options;
@@ -184,7 +180,7 @@ final class SessionManager extends AbstractManager
             /** @var EnvironmentInterface $initialEnvironment */
             $initialEnvironment = unserialize($storage['environment']);
         } else {
-            $initialEnvironment = $this->environmentClass::fromGlobals($_SERVER);
+            $initialEnvironment = $this->environmentFactory->getEnvironment();
             $this->getStorage()->setMetadata('environment', serialize($initialEnvironment));
         }
 
@@ -197,7 +193,7 @@ final class SessionManager extends AbstractManager
             $validatorChain = $this->getValidatorChain();
             $validator      = new $validatorName(
                 $initialEnvironment,
-                $this->environmentClass::fromGlobals($_SERVER),
+                $this->environmentFactory->getEnvironment(),
                 $this->options
             );
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -6,8 +6,8 @@ namespace Laminas\Session;
 
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerInterface;
-use Laminas\Session\Service\EnvironmentFactory;
 use Laminas\Session\Service\EnvironmentFactoryInterface;
+use Laminas\Session\Service\GlobalEnvironmentFactory;
 use Laminas\Session\Validator\EnvironmentInterface;
 use Laminas\Session\Validator\ValidatorInterface;
 use Traversable;
@@ -84,7 +84,7 @@ final class SessionManager extends AbstractManager
         $this->preserveStorage    = $options['preserve_storage'] ?? false;
         $this->sendExpireCookie   = $options['send_expire_cookie'] ?? true;
         $this->clearStorage       = $options['clear_storage'] ?? false;
-        $this->environmentFactory = $environmentFactory ?? new EnvironmentFactory();
+        $this->environmentFactory = $environmentFactory ?? new GlobalEnvironmentFactory();
 
         if ($options['attach_default_validators'] ?? true) {
             $validators = array_merge($this->defaultValidators, $validators);

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -7,6 +7,7 @@ namespace Laminas\Session;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Session\Validator\Environment;
+use Laminas\Session\Validator\EnvironmentInterface;
 use Laminas\Session\Validator\ValidatorInterface;
 use Traversable;
 
@@ -16,6 +17,7 @@ use function assert;
 use function headers_sent;
 use function is_array;
 use function is_string;
+use function is_subclass_of;
 use function iterator_to_array;
 use function preg_match;
 use function register_shutdown_function;
@@ -62,6 +64,9 @@ final class SessionManager extends AbstractManager
 
     protected array $options = [];
 
+    /** @var class-string<EnvironmentInterface> */
+    protected string $environmentClass = Environment::class;
+
     /**
      * Constructor
      *
@@ -74,7 +79,8 @@ final class SessionManager extends AbstractManager
         ?Storage\StorageInterface $storage = null,
         ?SaveHandler\SaveHandlerInterface $saveHandler = null,
         array $validators = [],
-        array $options = []
+        array $options = [],
+        ?string $currentEnvironment = null
     ) {
         $this->preserveStorage  = $options['preserve_storage'] ?? false;
         $this->sendExpireCookie = $options['send_expire_cookie'] ?? true;
@@ -82,6 +88,10 @@ final class SessionManager extends AbstractManager
 
         if ($options['attach_default_validators'] ?? true) {
             $validators = array_merge($this->defaultValidators, $validators);
+        }
+
+        if (is_string($currentEnvironment) && is_subclass_of($currentEnvironment, EnvironmentInterface::class)) {
+            $this->environmentClass = $currentEnvironment;
         }
 
         $this->options = $options;
@@ -169,25 +179,27 @@ final class SessionManager extends AbstractManager
         /** @var array<string, mixed> $storage */
         $storage = $this->getStorage()->getMetadata();
 
+        if (isset($storage['environment'])) {
+            assert(is_string($storage['environment']));
+            /** @var EnvironmentInterface $initialEnvironment */
+            $initialEnvironment = unserialize($storage['environment']);
+        } else {
+            $initialEnvironment = $this->environmentClass::fromGlobals($_SERVER);
+            $this->getStorage()->setMetadata('environment', serialize($initialEnvironment));
+        }
+
         foreach ($this->validators as $validatorName) {
             $validatorValues = $this->getStorage()->getMetadata('_VALID');
             if (is_array($validatorValues) && array_key_exists($validatorName, $validatorValues)) {
                 continue;
             }
 
-            if (isset($storage['environment'])) {
-                assert(is_string($storage['environment']));
-                /** @var Environment $initialEnvironment */
-                $initialEnvironment = unserialize($storage['environment']);
-            } else {
-                $initialEnvironment = Environment::fromGlobals($_SERVER);
-                $this->getStorage()->setMetadata('environment', serialize($initialEnvironment));
-            }
-
-            $currentEnvironment = Environment::fromGlobals($_SERVER);
-
             $validatorChain = $this->getValidatorChain();
-            $validator      = new $validatorName($initialEnvironment, $currentEnvironment, $this->options);
+            $validator      = new $validatorName(
+                $initialEnvironment,
+                $this->environmentClass::fromGlobals($_SERVER),
+                $this->options
+            );
 
             $validatorChain->attach('session.validate', [$validator, 'isValid']);
         }

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -80,7 +80,7 @@ final class SessionManager extends AbstractManager
         ?SaveHandler\SaveHandlerInterface $saveHandler = null,
         array $validators = [],
         array $options = [],
-        ?string $currentEnvironment = null
+        ?string $environmentClass = null
     ) {
         $this->preserveStorage  = $options['preserve_storage'] ?? false;
         $this->sendExpireCookie = $options['send_expire_cookie'] ?? true;
@@ -90,8 +90,8 @@ final class SessionManager extends AbstractManager
             $validators = array_merge($this->defaultValidators, $validators);
         }
 
-        if (is_string($currentEnvironment) && is_subclass_of($currentEnvironment, EnvironmentInterface::class)) {
-            $this->environmentClass = $currentEnvironment;
+        if (is_string($environmentClass) && is_subclass_of($environmentClass, EnvironmentInterface::class)) {
+            $this->environmentClass = $environmentClass;
         }
 
         $this->options = $options;

--- a/src/Validator/Environment.php
+++ b/src/Validator/Environment.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Laminas\Session\Validator;
 
+use function assert;
 use function is_string;
+use function serialize;
 use function session_id;
+use function unserialize;
 
 final class Environment implements EnvironmentInterface
 {
     public function __construct(
-        public readonly ?string $userAgent = null,
-        public readonly ?string $remoteAddr = null,
-        public readonly ?string $forwardedFor = null,
-        public readonly ?string $sessionId = null
+        private readonly ?string $userAgent = null,
+        private readonly ?string $remoteAddr = null,
+        private readonly ?string $forwardedFor = null,
+        private readonly ?string $sessionId = null
     ) {
     }
 
@@ -54,5 +57,40 @@ final class Environment implements EnvironmentInterface
     public function getSessionId(): ?string
     {
         return $this->sessionId;
+    }
+
+    public function serialize(): string
+    {
+        return serialize($this);
+    }
+
+    public function unserialize(string $data): Environment
+    {
+        $environment = unserialize($data);
+        assert($environment instanceof Environment);
+        return $environment;
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'userAgent'    => $this->getUserAgent(),
+            'remoteAddr'   => $this->getRemoteAddr(),
+            'forwardedFor' => $this->getForwardedFor(),
+            'sessionId'    => $this->getSessionId(),
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        assert(is_string($data['userAgent']) || $data['userAgent'] === null);
+        assert(is_string($data['remoteAddr']) || $data['remoteAddr'] === null);
+        assert(is_string($data['forwardedFor']) || $data['forwardedFor'] === null);
+        assert(is_string($data['sessionId']) || $data['sessionId'] === null);
+
+        $this->userAgent    = $data['userAgent'];
+        $this->remoteAddr   = $data['remoteAddr'];
+        $this->forwardedFor = $data['forwardedFor'];
+        $this->sessionId    = $data['sessionId'];
     }
 }

--- a/src/Validator/EnvironmentInterface.php
+++ b/src/Validator/EnvironmentInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Session\Validator;
 
-interface EnvironmentInterface
+use Serializable;
+
+interface EnvironmentInterface extends Serializable
 {
     public function getUserAgent(): ?string;
 

--- a/src/Validator/EnvironmentInterface.php
+++ b/src/Validator/EnvironmentInterface.php
@@ -6,8 +6,6 @@ namespace Laminas\Session\Validator;
 
 interface EnvironmentInterface
 {
-    public static function fromGlobals(array $data): self;
-
     public function getUserAgent(): ?string;
 
     public function getRemoteAddr(): ?string;

--- a/src/Validator/EnvironmentInterface.php
+++ b/src/Validator/EnvironmentInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Session\Validator;
+
+interface EnvironmentInterface
+{
+    public static function fromGlobals(array $data): self;
+
+    public function getUserAgent(): ?string;
+
+    public function getRemoteAddr(): ?string;
+
+    public function getForwardedFor(): ?string;
+
+    public function getSessionId(): ?string;
+}

--- a/src/Validator/HttpUserAgent.php
+++ b/src/Validator/HttpUserAgent.php
@@ -11,8 +11,8 @@ final class HttpUserAgent implements ValidatorInterface
      * get the current user agent and store it in the session as 'valid data'
      */
     public function __construct(
-        public readonly Environment $initial,
-        public readonly Environment $current,
+        public readonly EnvironmentInterface $initial,
+        public readonly EnvironmentInterface $current,
         array $option = []
     ) {
     }
@@ -23,7 +23,7 @@ final class HttpUserAgent implements ValidatorInterface
      */
     public function isValid(): bool
     {
-        return $this->initial->userAgent === $this->current->userAgent;
+        return $this->initial->getUserAgent() === $this->current->getUserAgent();
     }
 
     /**

--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -19,13 +19,10 @@ final class Id implements ValidatorInterface
 {
     /**
      * Constructor
-     *
-     * Allows passing the current session_id; if none provided, uses the PHP
-     * session_id() function to retrieve it.
      */
     public function __construct(
-        public readonly Environment $initial,
-        public readonly Environment $current,
+        public readonly EnvironmentInterface $initial,
+        public readonly EnvironmentInterface $current,
         array $options = []
     ) {
     }
@@ -37,7 +34,8 @@ final class Id implements ValidatorInterface
      */
     public function isValid(): bool
     {
-        if ($this->current->sessionId === null) {
+        $sessionId = $this->current->getSessionId();
+        if ($sessionId === null) {
             return false;
         }
 
@@ -57,7 +55,7 @@ final class Id implements ValidatorInterface
             default => '#^[0-9a-v]*$#',
         };
 
-        return (bool) preg_match($pattern, $this->current->sessionId);
+        return (bool) preg_match($pattern, $sessionId);
     }
 
     /**

--- a/src/Validator/RemoteAddr.php
+++ b/src/Validator/RemoteAddr.php
@@ -16,7 +16,6 @@ use function in_array;
  * @psalm-type OptionsArgument = array{
  * use_proxy?: bool,
  * trusted_proxies?: array<string>,
- * proxy_header?: non-empty-string,
  * }
  */
 final class RemoteAddr implements SessionValidator
@@ -31,16 +30,16 @@ final class RemoteAddr implements SessionValidator
      * @param OptionsArgument $options
      */
     public function __construct(
-        public readonly Environment $initial,
-        public readonly Environment $current,
+        public readonly EnvironmentInterface $initial,
+        public readonly EnvironmentInterface $current,
         array $options = []
     ) {
         if (isset($options['use_proxy']) && $options['use_proxy'] === true) {
             $this->initialData = $this->getIpAddress($this->initial, $options);
             $this->currentData = $this->getIpAddress($this->current, $options);
         } else {
-            $this->initialData = $this->initial->remoteAddr;
-            $this->currentData = $this->current->remoteAddr;
+            $this->initialData = $this->initial->getRemoteAddr();
+            $this->currentData = $this->current->getRemoteAddr();
         }
     }
 
@@ -58,7 +57,7 @@ final class RemoteAddr implements SessionValidator
      *
      * @param OptionsArgument $options
      */
-    public static function getIpAddress(Environment $initial, array $options = []): ?string
+    public static function getIpAddress(EnvironmentInterface $initial, array $options = []): ?string
     {
         $ip = self::getIpAddressFromProxy($initial, $options);
 
@@ -66,8 +65,8 @@ final class RemoteAddr implements SessionValidator
             return $ip;
         }
 
-        if ($initial->remoteAddr !== null) {
-            return $initial->remoteAddr;
+        if ($initial->getRemoteAddr() !== null) {
+            return $initial->getRemoteAddr();
         }
 
         return null;
@@ -80,18 +79,18 @@ final class RemoteAddr implements SessionValidator
      *
      * @param OptionsArgument $options
      */
-    private static function getIpAddressFromProxy(Environment $initial, array $options = []): string|false
+    private static function getIpAddressFromProxy(EnvironmentInterface $initial, array $options = []): string|false
     {
         $trustedProxies = $options['trusted_proxies'] ?? [];
 
         if (
             ! (isset($options['use_proxy']) && $options['use_proxy'])
-            || ($initial->remoteAddr !== null && ! in_array($initial->remoteAddr, $trustedProxies))
+            || ($initial->getRemoteAddr() !== null && ! in_array($initial->getRemoteAddr(), $trustedProxies))
         ) {
             return false;
         }
 
-        $proxyHeader = $initial->forwardedFor;
+        $proxyHeader = $initial->getForwardedFor();
 
         if ($proxyHeader === null || $proxyHeader === '') {
             return false;

--- a/src/Validator/ValidatorInterface.php
+++ b/src/Validator/ValidatorInterface.php
@@ -12,7 +12,7 @@ namespace Laminas\Session\Validator;
 interface ValidatorInterface
 {
     /** @param OptionsArgument $options */
-    public function __construct(Environment $initial, Environment $current, array $options = []);
+    public function __construct(EnvironmentInterface $initial, EnvironmentInterface $current, array $options = []);
 
     /**
      * This method will be called at the beginning of

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -19,6 +19,7 @@ use Laminas\Session\Validator\Id;
 use Laminas\Session\Validator\RemoteAddr;
 use LaminasTest\Session\TestAsset\Php81CompatibleStorageInterface;
 use LaminasTest\Session\TestAsset\TestCustomEnvironment;
+use LaminasTest\Session\TestAsset\TestCustomEnvironmentFactory;
 use LaminasTest\Session\TestAsset\TestFailingValidator;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -829,7 +830,7 @@ class SessionManagerTest extends TestCase
     #[IgnoreDeprecations]
     public function testValidatorChainSessionMetadataIsPreservedWithCustomEnvironment(): void
     {
-        $this->manager = new SessionManager(environmentClass: TestCustomEnvironment::class);
+        $this->manager = new SessionManager(environmentFactory: new TestCustomEnvironmentFactory());
         self::assertFalse($this->manager->sessionExists());
         $this->manager->start();
         $environment = unserialize((string) $this->manager->getStorage()->getMetadata('environment'));

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -18,6 +18,7 @@ use Laminas\Session\Validator\Environment;
 use Laminas\Session\Validator\Id;
 use Laminas\Session\Validator\RemoteAddr;
 use LaminasTest\Session\TestAsset\Php81CompatibleStorageInterface;
+use LaminasTest\Session\TestAsset\TestCustomEnvironment;
 use LaminasTest\Session\TestAsset\TestFailingValidator;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -55,14 +56,11 @@ class SessionManagerTest extends TestCase
 {
     use ReflectionPropertyTrait;
 
-    /** @var false|string */
-    public $error;
+    public false|string $error;
 
-    /** @var string */
-    public $cookieDateFormat = 'D, d-M-y H:i:s e';
+    public string $cookieDateFormat = 'D, d-M-y H:i:s e';
 
-    /** @var SessionManager */
-    protected $manager;
+    protected SessionManager $manager;
 
     protected function setUp(): void
     {
@@ -825,6 +823,35 @@ class SessionManagerTest extends TestCase
             Environment::fromGlobals($_SERVER),
             unserialize((string) $_SESSION['__Laminas']['environment'])
         );
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testValidatorChainSessionMetadataIsPreservedWithCustomEnvironment(): void
+    {
+        $this->manager = new SessionManager(currentEnvironment: TestCustomEnvironment::class);
+        self::assertFalse($this->manager->sessionExists());
+        $this->manager->start();
+        $environment = unserialize((string) $this->manager->getStorage()->getMetadata('environment'));
+        assert($environment instanceof TestCustomEnvironment);
+        $this->manager->getValidatorChain()
+            ->attach('session.validate', [
+                new RemoteAddr(
+                    $environment,
+                    TestCustomEnvironment::fromGlobals($_SERVER)
+                ),
+                'isValid',
+            ]);
+        $preservedData  = unserialize((string) $_SESSION['__Laminas']['environment']);
+        $newEnvironment = TestCustomEnvironment::fromGlobals($_SERVER);
+
+        self::assertIsArray($_SESSION['__Laminas']['_VALID']);
+        self::assertIsString($_SESSION['__Laminas']['_VALID'][0]);
+        self::assertInstanceOf(TestCustomEnvironment::class, $preservedData);
+
+        self::assertEquals('fistCustomValue', $preservedData->getFirstCustomProperty());
+        self::assertEquals('secondCustomValue', $preservedData->getSecondCustomProperty());
+        self::assertEquals($newEnvironment, $preservedData);
     }
 
     #[RunInSeparateProcess]

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -829,7 +829,7 @@ class SessionManagerTest extends TestCase
     #[IgnoreDeprecations]
     public function testValidatorChainSessionMetadataIsPreservedWithCustomEnvironment(): void
     {
-        $this->manager = new SessionManager(currentEnvironment: TestCustomEnvironment::class);
+        $this->manager = new SessionManager(environmentClass: TestCustomEnvironment::class);
         self::assertFalse($this->manager->sessionExists());
         $this->manager->start();
         $environment = unserialize((string) $this->manager->getStorage()->getMetadata('environment'));

--- a/test/TestAsset/TestCustomEnvironment.php
+++ b/test/TestAsset/TestCustomEnvironment.php
@@ -2,38 +2,52 @@
 
 declare(strict_types=1);
 
-namespace Laminas\Session\Validator;
+namespace LaminasTest\Session\TestAsset;
+
+use Laminas\Session\Validator\EnvironmentInterface;
 
 use function is_string;
 use function session_id;
 
-final class Environment implements EnvironmentInterface
+class TestCustomEnvironment implements EnvironmentInterface
 {
     public function __construct(
         public readonly ?string $userAgent = null,
         public readonly ?string $remoteAddr = null,
         public readonly ?string $forwardedFor = null,
-        public readonly ?string $sessionId = null
+        public readonly ?string $sessionId = null,
+        public readonly string $firstCustomProperty = 'fistCustomValue',
+        public readonly string $secondCustomProperty = 'secondCustomValue',
     ) {
     }
 
     public static function fromGlobals(array $data): self
     {
         $userAgent = isset($data['HTTP_USER_AGENT']) && is_string($data['HTTP_USER_AGENT'])
-            ? $data['HTTP_USER_AGENT']
-            : null;
+        ? $data['HTTP_USER_AGENT']
+        : null;
 
         $remoteAddr = isset($data['REMOTE_ADDR']) && is_string($data['REMOTE_ADDR'])
-            ? $data['REMOTE_ADDR']
-            : null;
+        ? $data['REMOTE_ADDR']
+        : null;
 
         $forwardedFor = isset($data['HTTP_X_FORWARDED_FOR']) && is_string($data['HTTP_X_FORWARDED_FOR'])
-            ? $data['HTTP_X_FORWARDED_FOR']
-            : null;
+        ? $data['HTTP_X_FORWARDED_FOR']
+        : null;
 
         $sessionId = session_id();
 
-        return new self($userAgent, $remoteAddr, $forwardedFor, $sessionId);
+        $firstCustomProperty  = 'fistCustomValue';
+        $secondCustomProperty = 'secondCustomValue';
+
+        return new self(
+            $userAgent,
+            $remoteAddr,
+            $forwardedFor,
+            $sessionId,
+            $firstCustomProperty,
+            $secondCustomProperty
+        );
     }
 
     public function getUserAgent(): ?string
@@ -54,5 +68,15 @@ final class Environment implements EnvironmentInterface
     public function getSessionId(): ?string
     {
         return $this->sessionId;
+    }
+
+    public function getFirstCustomProperty(): string
+    {
+        return $this->firstCustomProperty;
+    }
+
+    public function getSecondCustomProperty(): string
+    {
+        return $this->secondCustomProperty;
     }
 }

--- a/test/TestAsset/TestCustomEnvironment.php
+++ b/test/TestAsset/TestCustomEnvironment.php
@@ -6,18 +6,21 @@ namespace LaminasTest\Session\TestAsset;
 
 use Laminas\Session\Validator\EnvironmentInterface;
 
+use function assert;
 use function is_string;
+use function serialize;
 use function session_id;
+use function unserialize;
 
 class TestCustomEnvironment implements EnvironmentInterface
 {
     public function __construct(
-        public readonly ?string $userAgent = null,
-        public readonly ?string $remoteAddr = null,
-        public readonly ?string $forwardedFor = null,
-        public readonly ?string $sessionId = null,
-        public readonly string $firstCustomProperty = 'fistCustomValue',
-        public readonly string $secondCustomProperty = 'secondCustomValue',
+        private readonly ?string $userAgent = null,
+        private readonly ?string $remoteAddr = null,
+        private readonly ?string $forwardedFor = null,
+        private readonly ?string $sessionId = null,
+        private readonly string $firstCustomProperty = 'fistCustomValue',
+        private readonly string $secondCustomProperty = 'secondCustomValue',
     ) {
     }
 
@@ -78,5 +81,46 @@ class TestCustomEnvironment implements EnvironmentInterface
     public function getSecondCustomProperty(): string
     {
         return $this->secondCustomProperty;
+    }
+
+    public function serialize(): string
+    {
+        return serialize($this->__serialize());
+    }
+
+    public function unserialize(string $data): TestCustomEnvironment
+    {
+        $environment = unserialize($data);
+        assert($environment instanceof TestCustomEnvironment);
+        return $environment;
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'userAgent'            => $this->getUserAgent(),
+            'remoteAddr'           => $this->getRemoteAddr(),
+            'forwardedFor'         => $this->getForwardedFor(),
+            'sessionId'            => $this->getSessionId(),
+            'firstCustomProperty'  => $this->getFirstCustomProperty(),
+            'secondCustomProperty' => $this->getSecondCustomProperty(),
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        assert(is_string($data['userAgent']) || $data['userAgent'] === null);
+        assert(is_string($data['remoteAddr']) || $data['remoteAddr'] === null);
+        assert(is_string($data['forwardedFor']) || $data['forwardedFor'] === null);
+        assert(is_string($data['sessionId']) || $data['sessionId'] === null);
+        assert(is_string($data['firstCustomProperty']));
+        assert(is_string($data['secondCustomProperty']));
+
+        $this->userAgent            = $data['userAgent'];
+        $this->remoteAddr           = $data['remoteAddr'];
+        $this->forwardedFor         = $data['forwardedFor'];
+        $this->sessionId            = $data['sessionId'];
+        $this->firstCustomProperty  = $data['firstCustomProperty'];
+        $this->secondCustomProperty = $data['secondCustomProperty'];
     }
 }

--- a/test/TestAsset/TestCustomEnvironmentFactory.php
+++ b/test/TestAsset/TestCustomEnvironmentFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Session\TestAsset;
+
+use Laminas\Session\Service\EnvironmentFactoryInterface;
+use Laminas\Session\Validator\EnvironmentInterface;
+
+class TestCustomEnvironmentFactory implements EnvironmentFactoryInterface
+{
+    public function getEnvironment(): EnvironmentInterface
+    {
+        return TestCustomEnvironment::fromGlobals($_SERVER);
+    }
+}

--- a/test/TestAsset/TestFailingValidator.php
+++ b/test/TestAsset/TestFailingValidator.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace LaminasTest\Session\TestAsset;
 
-use Laminas\Session\Validator\Environment;
+use Laminas\Session\Validator\EnvironmentInterface;
 use Laminas\Session\Validator\ValidatorInterface;
 
 final class TestFailingValidator implements ValidatorInterface
 {
-    public function __construct(Environment $initial, Environment $current, array $options = [])
+    public function __construct(EnvironmentInterface $initial, EnvironmentInterface $current, array $options = [])
     {
     }
 
-    public ?Environment $current = null;
+    public ?EnvironmentInterface $current = null;
     public function getName(): string
     {
         return self::class;

--- a/test/Validator/HttpUserAgentTest.php
+++ b/test/Validator/HttpUserAgentTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Session\Validator;
 
 use Laminas\Session\Validator\Environment;
 use Laminas\Session\Validator\HttpUserAgent;
+use LaminasTest\Session\TestAsset\TestCustomEnvironment;
 use PHPUnit\Framework\TestCase;
 
 class HttpUserAgentTest extends TestCase
@@ -16,6 +17,17 @@ class HttpUserAgentTest extends TestCase
         $validator                  = new HttpUserAgent(
             Environment::fromGlobals($_SERVER),
             Environment::fromGlobals($_SERVER)
+        );
+
+        self::assertTrue($validator->isValid());
+    }
+
+    public function testIsValidWithCustomEnvironment(): void
+    {
+        $_SERVER['HTTP_USER_AGENT'] = 'Test-User-Agent';
+        $validator                  = new HttpUserAgent(
+            TestCustomEnvironment::fromGlobals($_SERVER),
+            TestCustomEnvironment::fromGlobals($_SERVER)
         );
 
         self::assertTrue($validator->isValid());

--- a/test/Validator/IdTest.php
+++ b/test/Validator/IdTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Session\Validator;
 
 use Laminas\Session\Validator\Environment;
 use Laminas\Session\Validator\Id;
+use LaminasTest\Session\TestAsset\TestCustomEnvironment;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -44,6 +45,24 @@ class IdTest extends TestCase
         self::assertSame($isValid, $validator->isValid());
     }
 
+    #[IgnoreDeprecations]
+    #[DataProvider('id')]
+    #[RunInSeparateProcess]
+    public function testIsValidPhpWithCustomEnvironment(int $bitsPerCharacter, string $id, bool $isValid): void
+    {
+        ini_set('session.sid_bits_per_character', $bitsPerCharacter);
+
+        $validator = new Id(
+            TestCustomEnvironment::fromGlobals($_SERVER),
+            new TestCustomEnvironment(
+                sessionId: $id,
+                firstCustomProperty: 'fistCustomValue',
+                secondCustomProperty: 'secondCustomValue'
+            )
+        );
+        self::assertSame($isValid, $validator->isValid());
+    }
+
     /**
      * @runInSeparateProcess
      */
@@ -53,7 +72,7 @@ class IdTest extends TestCase
         $sessionId = session_id();
         $id        = new Id(Environment::fromGlobals($_SERVER), Environment::fromGlobals($_SERVER));
 
-        self::assertSame($sessionId, $id->initial->sessionId);
+        self::assertSame($sessionId, $id->initial->getSessionId());
     }
 
     public function testValidatorName(): void

--- a/test/Validator/RemoteAddrTest.php
+++ b/test/Validator/RemoteAddrTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Session\Validator;
 
 use Laminas\Session\Validator\Environment;
 use Laminas\Session\Validator\RemoteAddr;
+use LaminasTest\Session\TestAsset\TestCustomEnvironment;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -36,7 +37,7 @@ class RemoteAddrTest extends TestCase
         $_SERVER['REMOTE_ADDR'] = '0.1.2.3';
         $validator              =
             new RemoteAddr(Environment::fromGlobals($_SERVER), Environment::fromGlobals($_SERVER));
-        self::assertEquals('0.1.2.3', $validator->current->remoteAddr);
+        self::assertEquals('0.1.2.3', $validator->current->getRemoteAddr());
         $this->restore();
     }
 
@@ -59,7 +60,7 @@ class RemoteAddrTest extends TestCase
             Environment::fromGlobals($_SERVER),
             Environment::fromGlobals($_SERVER)
         );
-        self::assertEquals('0.1.2.3', $validator->current->remoteAddr);
+        self::assertEquals('0.1.2.3', $validator->current->getRemoteAddr());
         $this->restore();
     }
 
@@ -140,7 +141,7 @@ class RemoteAddrTest extends TestCase
             Environment::fromGlobals($_SERVER),
             $options
         );
-        self::assertEquals('0.1.2.3', $validator->current->remoteAddr);
+        self::assertEquals('0.1.2.3', $validator->current->getRemoteAddr());
         $this->restore();
     }
 
@@ -172,8 +173,7 @@ class RemoteAddrTest extends TestCase
         $_SERVER['HTTP_CLIENT_IP']       = '0.1.2.4';
 
         $options = [
-            'use_proxy'    => true,
-            'proxy_header' => 'Client-Ip',
+            'use_proxy' => true,
         ];
 
         $validator = new RemoteAddr(
@@ -181,7 +181,7 @@ class RemoteAddrTest extends TestCase
             Environment::fromGlobals($_SERVER),
             $options
         );
-        self::assertEquals('0.1.2.3', $validator->current->remoteAddr);
+        self::assertEquals('0.1.2.3', $validator->current->getRemoteAddr());
         $this->restore();
     }
 
@@ -197,10 +197,10 @@ class RemoteAddrTest extends TestCase
     public function testUnknownServerHeader(): void
     {
         $this->backup();
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = 'Unknow Header';
 
         $options = [
-            'use_proxy'    => true,
-            'proxy_header' => 'Unknown-Header',
+            'use_proxy' => true,
         ];
 
         $validator = new RemoteAddr(
@@ -208,7 +208,24 @@ class RemoteAddrTest extends TestCase
             Environment::fromGlobals($_SERVER),
             $options
         );
-        self::assertEmpty($validator->current->remoteAddr);
+        self::assertEmpty($validator->current->getRemoteAddr());
+        $this->restore();
+    }
+
+    public function testWithCustomEnvironment(): void
+    {
+        $this->backup();
+        $_SERVER['REMOTE_ADDR'] = '0.1.2.3';
+        $validator              =
+            new RemoteAddr(
+                new TestCustomEnvironment(
+                    remoteAddr:  '0.1.1.3',
+                    firstCustomProperty: 'fistCustomValue',
+                    secondCustomProperty: 'secondCustomValue'
+                ),
+                TestCustomEnvironment::fromGlobals($_SERVER)
+            );
+        self::assertFalse($validator->isValid());
         $this->restore();
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| RFC           | yes


### Description

Based on issue #152 , added a new `EnvironmentInterface` to allow users to create custom environments with additional properties if needed, and use them in current `SessionManager` flow.

Kept the existing `Environment` as the default for `SessionManager`, but users can provide a custom one via config under a new `environment` key.

```php
    'session_manager'    => [
        'environment' => AnyCustomEnvironment::class
    ],
```

Since properties can't be defined in the older supported  PHP versions, I've added getters to the `EnvironmentInterface` to force users to define the required properties for all existing validators, with any custom ones being extra.

One issue is that getters for public properties are unnecessary for the current `Environment` object, but psalm will throw a lot of `NoInterfaceProperties` in the validator classes, as the `Environment` parameters were replaced with `EnvironmentInterface`. I suppose they could be added to the baseline instead, and keep accessing public `Environment` properties as before if that's preferred.

Let me know of any issues, or any different approach preferable.

Once a proper solution is found i'll also document the changes.

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->
