### PR TITLE
[RFC] Lazy session start

### DIFF
--- a/docs/book/v3/container.md
+++ b/docs/book/v3/container.md
@@ -18,6 +18,12 @@ $container = new Container('namespace');
 $container->item = 'foo';
 ```
 
+## Lazy Container
+
+`Laminas\Session\LazyContainer` is another `Laminas\Session\AbstractContainer` implementation,
+which defers starting the session until it's needed: reading does not start it unless a session cookie is already present,
+while writing always does.
+
 ## Setting the Default Session Manager
 
 In the event you are using multiple session managers or prefer to be explicit,
@@ -30,3 +36,18 @@ use Laminas\Session\SessionManager;
 $manager = new SessionManager();
 Container::setDefaultManager($manager);
 ```
+
+## Creating Abstract Container Using The ManagerInterface
+
+`Laminas\Session\Service\ContainerAbstractServiceFactory` can be used to create `AbstractContainer` instances.
+The `session_containers` config array is used to hold the explicit instances, using a `ContainerName => class-string` naming convention.
+
+```php
+'session_containers' => [
+    'DefaultContainer',
+    'CustomLazyContainer' => \Laminas\Session\LazyContainer::class,
+]
+```
+
+The default `AbstractContainer` implementation is `Laminas\Session\Container::class`, and as such
+any container added without explicitly defining the implementation type will default to using it.

--- a/src/LazyContainer.php
+++ b/src/LazyContainer.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Session;
+
+use AllowDynamicProperties;
+use ArrayIterator;
+use ArrayObject;
+use Laminas\Session\ManagerInterface as Manager;
+use Traversable;
+
+use function assert;
+use function is_string;
+use function preg_match;
+use function session_status;
+
+use const PHP_SESSION_NONE;
+
+/**
+ * @template TKey of string
+ * @template TValue
+ * @template-extends AbstractContainer<TKey, TValue>
+ * @psalm-no-seal-properties
+ */
+#[AllowDynamicProperties]
+class LazyContainer extends AbstractContainer
+{
+    /**
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct(string $name = 'Default', ?Manager $manager = null)
+    {
+        if (! preg_match('/^[a-z0-9][a-z0-9_\\\\]+$/i', $name)) {
+            throw new Exception\InvalidArgumentException(
+                'Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only'
+            );
+        }
+
+        $this->name = $name;
+        $this->setManager($manager);
+
+        // AbstractContainer::__construct is not called here
+        // because it calls $this->getManager()->start(), thus starting the session automatically
+        ArrayObject::__construct([], ArrayObject::ARRAY_AS_PROPS);
+    }
+
+    private function startIfNeeded(bool $write): void
+    {
+        if (
+            $write ||
+            (session_status() === PHP_SESSION_NONE &&
+            isset($_COOKIE[$this->getManager()->getName()]))
+        ) {
+            $this->getManager()->start();
+        }
+    }
+
+    /**
+     * @param TKey|non-empty-string $offset
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->startIfNeeded(true);
+        parent::offsetSet($offset, $value);
+    }
+
+    /**
+     * @param array<TKey, TValue>|Traversable<TKey, TValue> $input
+     * @return array<TKey, TValue>
+     */
+    public function exchangeArray(object|array $input): array
+    {
+        $this->startIfNeeded(true);
+        return parent::exchangeArray($input);
+    }
+
+    /**
+     * @param string|array<TKey>|null $vars
+     * @return LazyContainer&static
+     */
+    public function setExpirationSeconds(int $ttl, string|array|null $vars = null): static
+    {
+        $this->startIfNeeded(true);
+        return parent::setExpirationSeconds($ttl, $vars);
+    }
+
+    /**
+     * @param string|array<TKey>|null $vars
+     */
+    public function setExpirationHops(int $hops, string|array|null $vars = null): static
+    {
+        $this->startIfNeeded(true);
+
+        /** @var static $result */
+        $result = parent::setExpirationHops($hops, $vars);
+
+        return $result;
+    }
+
+    /**
+     * @param TKey|non-empty-string $key
+     */
+    public function offsetExists(mixed $key): bool
+    {
+        assert(is_string($key) && $key !== '');
+
+        $this->startIfNeeded(false);
+
+        if (! $this->getManager()->sessionExists()) {
+            return false;
+        }
+
+        return parent::offsetExists($key);
+    }
+
+    /**
+     * @param TKey|non-empty-string $key
+     */
+    public function &offsetGet(mixed $key, mixed $default = null): mixed
+    {
+        assert(is_string($key) && $key !== '');
+
+        $ret = $default;
+
+        if (! $this->offsetExists($key)) {
+            return $ret;
+        }
+
+        $storage = $this->getStorage();
+        $name    = $this->getName();
+        $ret     = &$storage[$name][$key];
+
+        return $ret;
+    }
+
+    /**
+     * @return Traversable<TKey, TValue>
+     */
+    public function getIterator(): Traversable
+    {
+        $this->startIfNeeded(false);
+
+        if (! $this->getManager()->sessionExists()) {
+            return new ArrayIterator([]);
+        }
+
+        return parent::getIterator();
+    }
+
+    /**
+     * @return array<TKey, TValue>
+     */
+    public function getArrayCopy(): array
+    {
+        $this->startIfNeeded(false);
+
+        if (! $this->getManager()->sessionExists()) {
+            return [];
+        }
+
+        return parent::getArrayCopy();
+    }
+}

--- a/src/Service/ContainerAbstractServiceFactory.php
+++ b/src/Service/ContainerAbstractServiceFactory.php
@@ -7,20 +7,24 @@ namespace Laminas\Session\Service;
 // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
 
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Laminas\Session\AbstractContainer;
 use Laminas\Session\Container;
+use Laminas\Session\Exception\InvalidArgumentException;
 use Laminas\Session\ManagerInterface;
 use Psr\Container\ContainerInterface;
 
-use function array_change_key_case;
-use function array_flip;
 use function array_key_exists;
+use function is_a;
 use function is_array;
+use function is_int;
+use function is_string;
+use function sprintf;
 use function strtolower;
 
 /**
  * Session container abstract service factory.
  *
- * Allows creating Container instances, using the ManagerInterface
+ * Allows creating AbstractContainer instances, using the ManagerInterface
  * if present. Containers are named in a "session_containers" array in the
  * Config service:
  *
@@ -35,7 +39,8 @@ use function strtolower;
  * </code>
  *
  * <code>
- * $container = $services->get('MySessionContainer');
+ * $container     = $services->get('MySessionContainer');
+ * $lazyContainer = $services->get('MyLazyContainer');
  * </code>
  */
 final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
@@ -49,6 +54,10 @@ final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
      * Configuration key in which session containers live
      */
     private string $configKey = 'session_containers';
+
+    private string $defaultClassKey = Container::class;
+
+    private string $defaultContainerClass = Container::class;
 
     private ?ManagerInterface $sessionManager = null;
 
@@ -68,10 +77,16 @@ final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
     /**
      * Create and return a named container.
      */
-    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): Container
-    {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): AbstractContainer {
+        $config  = $this->getConfig($container);
+        $class   = $config[strtolower($requestedName)];
         $manager = $this->getSessionManager($container);
-        return new Container($requestedName, $manager);
+
+        return new $class($requestedName, $manager);
     }
 
     /**
@@ -83,27 +98,72 @@ final class ContainerAbstractServiceFactory implements AbstractFactoryInterface
             return $this->config;
         }
 
+        $this->config = [];
+
         if (! $container->has('config')) {
-            $this->config = [];
             return $this->config;
         }
 
         $config = $container->get('config');
-        if (! isset($config[$this->configKey]) || ! is_array($config[$this->configKey])) {
-            $this->config = [];
+
+        if (
+            ! is_array($config)
+            || ! isset($config[$this->configKey])
+            || ! is_array($config[$this->configKey])
+        ) {
             return $this->config;
         }
 
-        $config = $config[$this->configKey];
-        $config = array_flip($config);
+        $configuredContainers = $config[$this->configKey];
 
-        $this->config = array_change_key_case($config);
+        if (
+            isset($configuredContainers[$this->defaultClassKey])
+            && is_string($configuredContainers[$this->defaultClassKey])
+        ) {
+            $this->defaultContainerClass = $this->resolveClass($configuredContainers[$this->defaultClassKey]);
+        }
+
+        foreach ($configuredContainers as $key => $value) {
+            // Do not allow overwriting the default Container
+            if ($key === $this->defaultClassKey) {
+                continue;
+            }
+
+            if (is_int($key) && is_string($value)) {
+                $name  = strtolower($value);
+                $class = $this->defaultContainerClass;
+            } elseif (is_string($key) && is_string($value)) {
+                $name  = strtolower($key);
+                $class = $this->resolveClass($value);
+            } else {
+                continue;
+            }
+
+            $this->config[$name] = $class;
+        }
 
         return $this->config;
     }
 
     /**
-     * Retrieve the session manager instance, if any
+     * @return class-string<AbstractContainer>
+     * @throws InvalidArgumentException
+     */
+    private function resolveClass(string $class): string
+    {
+        if (! is_a($class, AbstractContainer::class, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Container class "%s" is invalid; must be a subclass of %s',
+                $class,
+                AbstractContainer::class
+            ));
+        }
+
+        return $class;
+    }
+
+    /**
+     * Retrieve the session manager instance, if any.
      */
     private function getSessionManager(ContainerInterface $container): ?ManagerInterface
     {

--- a/test/LazyContainerTest.php
+++ b/test/LazyContainerTest.php
@@ -1,0 +1,691 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Session;
+
+use ArrayObject;
+use Laminas\Session\Config\SessionConfig;
+use Laminas\Session\Config\StandardConfig;
+use Laminas\Session\Exception\InvalidArgumentException;
+use Laminas\Session\LazyContainer;
+use Laminas\Session\ManagerInterface as Manager;
+use Laminas\Session\SessionManager;
+use Laminas\Session\Storage\ArrayStorage;
+use Laminas\Session\Storage\SessionArrayStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+use function microtime;
+use function sleep;
+use function time;
+
+/**
+ * @psalm-import-type SessionManagerType from SessionManager
+ */
+#[CoversClass(LazyContainer::class)]
+final class LazyContainerTest extends TestCase
+{
+    protected Manager $manager;
+
+    protected LazyContainer $container;
+
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+        $_COOKIE  = [];
+        LazyContainer::setDefaultManager(null);
+
+        $manager         = new SessionManager(new SessionConfig());
+        $this->manager   = $manager;
+        $this->container = new LazyContainer('Default', $manager);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        $_COOKIE  = [];
+        LazyContainer::setDefaultManager(null);
+    }
+
+    public function testInstantiationDoesNotStartSession(): void
+    {
+        $this->manager->destroy();
+        $container = new LazyContainer('Lazy', $this->manager);
+        self::assertFalse($this->manager->sessionExists());
+    }
+
+    public function testInstantiatingContainerWithoutNameUsesDefaultAsName(): void
+    {
+        self::assertEquals('Default', $this->container->getName());
+    }
+
+    public function testPassingNameToConstructorInstantiatesContainerWithThatName(): void
+    {
+        $container = new LazyContainer('foo', $this->manager);
+        self::assertEquals('foo', $container->getName());
+    }
+
+    public function testPassingNameStartingWithDigitToConstructorInstantiatesContainerWithThatName(): void
+    {
+        $container = new LazyContainer('0foo', $this->manager);
+        self::assertEquals('0foo', $container->getName());
+    }
+
+    public function testPassingInvalidNameToConstructorRaisesException(): void
+    {
+        $tries = [
+            'f!',
+            'foo bar',
+            '_foo',
+            '__foo',
+            '\foo',
+            '\\foo',
+        ];
+        foreach ($tries as $try) {
+            try {
+                $lazyContainer = new LazyContainer($try);
+                self::fail('Invalid container name should raise exception');
+            } catch (InvalidArgumentException $e) {
+                self::assertStringContainsString('invalid', $e->getMessage());
+            }
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testContainerActsAsArray(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        $container['foo'] = 'bar';
+
+        self::assertTrue(isset($container['foo']));
+        self::assertEquals('bar', $container['foo']);
+
+        unset($container['foo']);
+        self::assertFalse(isset($container['foo']));
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testContainerActsAsObject(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        $container->foo = 'bar';
+
+        self::assertTrue(isset($container->foo));
+        self::assertEquals('bar', $container->foo);
+
+        unset($container->foo);
+        self::assertFalse(isset($container->foo));
+    }
+
+    public function testDefaultManagerIsAlwaysPopulated(): void
+    {
+        $manager = LazyContainer::getDefaultManager();
+        self::assertInstanceOf(Manager::class, $manager);
+    }
+
+    public function testCanSetDefaultManager(): void
+    {
+        $manager = new TestAsset\TestManager();
+        LazyContainer::setDefaultManager($manager);
+        self::assertSame($manager, LazyContainer::getDefaultManager());
+    }
+
+    public function testCanSetDefaultManagerToNull(): void
+    {
+        $manager = new TestAsset\TestManager();
+        LazyContainer::setDefaultManager($manager);
+        LazyContainer::setDefaultManager(null);
+        self::assertNotSame($manager, LazyContainer::getDefaultManager());
+    }
+
+    public function testDefaultManagerUsedWhenNoManagerProvided(): void
+    {
+        $manager   = LazyContainer::getDefaultManager();
+        $container = new LazyContainer();
+        self::assertSame($manager, $container->getManager());
+    }
+
+    public function testContainerInstantiatesManagerWithDefaultsWhenNotInjected(): void
+    {
+        $container = new LazyContainer();
+        $manager   = $container->getManager();
+        self::assertInstanceOf(Manager::class, $manager);
+        $config = $manager->getConfig();
+        self::assertInstanceOf(SessionConfig::class, $config);
+        $storage = $manager->getStorage();
+        self::assertInstanceOf(SessionArrayStorage::class, $storage);
+    }
+
+    public function testContainerAllowsInjectingManagerViaConstructor(): void
+    {
+        $config    = new StandardConfig();
+        $manager   = new TestAsset\TestManager($config);
+        $container = new LazyContainer('Foo', $manager);
+        self::assertSame($manager, $container->getManager());
+    }
+
+    public function testContainerWritesToStorage(): void
+    {
+        $this->container->foo = 'bar';
+        $storage              = $this->manager->getStorage();
+        self::assertTrue(isset($storage['Default']));
+        self::assertTrue(isset($storage['Default']['foo']));
+        self::assertEquals('bar', $storage['Default']['foo']);
+
+        unset($this->container->foo);
+        self::assertFalse(isset($storage['Default']['foo']));
+    }
+
+    public function testSettingExpirationSecondsUpdatesStorageMetadataForFullContainer(): void
+    {
+        $currentTimestamp = time();
+        $this->container->setExpirationSeconds(3600);
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata($this->container->getName());
+        self::assertArrayHasKey('EXPIRE', $metadata);
+        self::assertEquals($currentTimestamp + 3600, $metadata['EXPIRE']);
+    }
+
+    public function testSettingExpirationSecondsForIndividualKeyUpdatesStorageMetadataForThatKey(): void
+    {
+        $this->container->foo = 'bar';
+        $currentTimestamp     = time();
+        $this->container->setExpirationSeconds(3600, 'foo');
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata($this->container->getName());
+        self::assertArrayHasKey('EXPIRE_KEYS', $metadata);
+        self::assertArrayHasKey('foo', $metadata['EXPIRE_KEYS']);
+        self::assertEquals($currentTimestamp + 3600, $metadata['EXPIRE_KEYS']['foo']);
+    }
+
+    public function testMultipleCallsToExpirationSecondsAggregates(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $this->container->baz = 'bat';
+        $this->container->bat = 'bas';
+        $currentTimestamp     = time();
+        $this->container->setExpirationSeconds(3600);
+        $this->container->setExpirationSeconds(1800, 'foo');
+        $this->container->setExpirationSeconds(900, ['baz', 'bat']);
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata($this->container->getName());
+        self::assertEquals($currentTimestamp + 1800, $metadata['EXPIRE_KEYS']['foo']);
+        self::assertEquals($currentTimestamp + 900, $metadata['EXPIRE_KEYS']['baz']);
+        self::assertEquals($currentTimestamp + 900, $metadata['EXPIRE_KEYS']['bat']);
+        self::assertEquals($currentTimestamp + 3600, $metadata['EXPIRE']);
+    }
+
+    public function testSettingExpirationSecondsUsesCurrentTime(): void
+    {
+        sleep(3);
+        $this->container->setExpirationSeconds(2);
+        $this->container->foo = 'bar';
+
+        // Simulate a second request: overwrite the request time with current time()
+        $_SERVER['REQUEST_TIME']       = time();
+        $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
+
+        self::assertEquals('bar', $this->container->foo);
+    }
+
+    public function testPassingUnsetKeyToSetExpirationSecondsDoesNothing(): void
+    {
+        $this->container->setExpirationSeconds(3600, 'foo');
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata($this->container->getName());
+        self::assertFalse(isset($metadata['EXPIRE_KEYS']['foo']));
+    }
+
+    public function testPassingUnsetKeyInArrayToSetExpirationSecondsDoesNothing(): void
+    {
+        $this->container->setExpirationSeconds(3600, ['foo']);
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata($this->container->getName());
+        self::assertFalse(isset($metadata['EXPIRE_KEYS']['foo']));
+    }
+
+    public function testGetKeyWithContainerExpirationInPastResetsToNull(): void
+    {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+        $this->container->foo = 'bar';
+        $storage              = $this->manager->getStorage();
+        $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
+        self::assertNull($this->container->foo);
+    }
+
+    public function testGetKeyWithExpirationInPastResetsToNull(): void
+    {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $storage              = $this->manager->getStorage();
+        $storage->setMetadata('Default', ['EXPIRE_KEYS' => ['foo' => $_SERVER['REQUEST_TIME'] - 18600]]);
+        self::assertNull($this->container->foo);
+        self::assertEquals('baz', $this->container->bar);
+    }
+
+    public function testKeyExistsWithContainerExpirationInPastReturnsFalse(): void
+    {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+        $this->container->foo = 'bar';
+        $storage              = $this->manager->getStorage();
+        $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
+        self::assertFalse(isset($this->container->foo));
+    }
+
+    public function testKeyExistsWithExpirationInPastReturnsFalse(): void
+    {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $storage              = $this->manager->getStorage();
+        $storage->setMetadata('Default', ['EXPIRE_KEYS' => ['foo' => $_SERVER['REQUEST_TIME'] - 18600]]);
+        self::assertFalse(isset($this->container->foo));
+        self::assertTrue(isset($this->container->bar));
+    }
+
+    public function testKeyExistsWithContainerExpirationInPastWithSetExpirationSecondsReturnsFalse(): void
+    {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+        $this->container->foo = 'bar';
+        $storage              = $this->manager->getStorage();
+        $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
+        $this->container->setExpirationSeconds(1);
+        self::assertFalse(isset($this->container->foo));
+    }
+
+    public function testSettingExpiredKeyOverwritesExpiryMetadataForThatKey(): void
+    {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+        $this->container->foo = 'bar';
+        $storage              = $this->manager->getStorage();
+        $storage->setMetadata('Default', ['EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600]);
+        $this->container->foo = 'baz';
+        self::assertTrue(isset($this->container->foo));
+        self::assertEquals('baz', $this->container->foo);
+        $metadata = $storage->getMetadata('Default');
+        self::assertFalse(isset($metadata['EXPIRE_KEYS']['foo']));
+    }
+
+    public function testSettingExpirationHopsWithNoVariablesMarksContainerByWritingToStorage(): void
+    {
+        $this->container->setExpirationHops(2);
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata('Default');
+        self::assertArrayHasKey('EXPIRE_HOPS', $metadata);
+        self::assertEquals(
+            ['hops' => 2, 'ts' => $storage->getRequestAccessTime()],
+            $metadata['EXPIRE_HOPS']
+        );
+    }
+
+    public function testSettingExpirationHopsWithSingleKeyMarksContainerByWritingToStorage(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->setExpirationHops(2, 'foo');
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata('Default');
+        self::assertArrayHasKey('EXPIRE_HOPS_KEYS', $metadata);
+        self::assertArrayHasKey('foo', $metadata['EXPIRE_HOPS_KEYS']);
+        self::assertEquals(
+            ['hops' => 2, 'ts' => $storage->getRequestAccessTime()],
+            $metadata['EXPIRE_HOPS_KEYS']['foo']
+        );
+    }
+
+    public function testSettingExpirationHopsWithMultipleKeysMarksContainerByWritingToStorage(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $this->container->baz = 'bat';
+        $this->container->setExpirationHops(2, ['foo', 'baz']);
+        $storage  = $this->manager->getStorage();
+        $metadata = $storage->getMetadata('Default');
+        self::assertArrayHasKey('EXPIRE_HOPS_KEYS', $metadata);
+
+        $hops     = $metadata['EXPIRE_HOPS_KEYS'];
+        $ts       = $storage->getRequestAccessTime();
+        $expected = [
+            'foo' => [
+                'hops' => 2,
+                'ts'   => $ts,
+            ],
+            'baz' => [
+                'hops' => 2,
+                'ts'   => $ts,
+            ],
+        ];
+        self::assertEquals($expected, $hops);
+    }
+
+    public function testContainerExpiresAfterSpecifiedHops(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->setExpirationHops(1);
+
+        $storage = $this->manager->getStorage();
+        $ts      = $storage->getRequestAccessTime();
+
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 60.0);
+        self::assertEquals('bar', $this->container->foo);
+
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 120.0);
+        self::assertNull($this->container->foo);
+    }
+
+    public function testInstantiatingMultipleContainersInSameRequestDoesNotCreateExtraHops(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->setExpirationHops(1);
+
+        $container = new LazyContainer('Default', $this->manager);
+        self::assertEquals('bar', $container->foo);
+        self::assertEquals('bar', $this->container->foo);
+    }
+
+    public function testKeyExpiresAfterSpecifiedHops(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $this->container->setExpirationHops(1, 'foo');
+
+        $storage = $this->manager->getStorage();
+        $ts      = $storage->getRequestAccessTime();
+
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 60.0);
+        self::assertEquals('bar', $this->container->foo);
+        self::assertEquals('baz', $this->container->bar);
+
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 120.0);
+        self::assertNull($this->container->foo);
+        self::assertEquals('baz', $this->container->bar);
+    }
+
+    public function testInstantiatingMultipleContainersInSameRequestDoesNotCreateExtraKeyHops(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $this->container->setExpirationHops(1, 'foo');
+
+        $container = new LazyContainer('Default', $this->manager);
+        self::assertEquals('bar', $container->foo);
+        self::assertEquals('bar', $this->container->foo);
+        self::assertEquals('baz', $container->bar);
+        self::assertEquals('baz', $this->container->bar);
+    }
+
+    public function testKeysExpireAfterSpecifiedHops(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $this->container->baz = 'bat';
+        $this->container->setExpirationHops(1, ['foo', 'baz']);
+
+        $storage = $this->manager->getStorage();
+        $ts      = $storage->getRequestAccessTime();
+
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 60.0);
+        self::assertEquals('bar', $this->container->foo);
+        self::assertEquals('baz', $this->container->bar);
+        self::assertEquals('bat', $this->container->baz);
+
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 120.0);
+        self::assertNull($this->container->foo);
+        self::assertEquals('baz', $this->container->bar);
+        self::assertNull($this->container->baz);
+    }
+
+    public function testCanIterateOverContainer(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $this->container->baz = 'bat';
+        $expected             = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'baz' => 'bat',
+        ];
+        $test                 = [];
+        foreach ($this->container as $key => $value) {
+            $test[$key] = $value;
+        }
+        self::assertSame($expected, $test);
+    }
+
+    public function testIterationHonorsExpirationHops(): void
+    {
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $this->container->baz = 'bat';
+        $this->container->setExpirationHops(1, ['foo', 'baz']);
+
+        $storage = $this->manager->getStorage();
+        $ts      = $storage->getRequestAccessTime();
+
+        // First hop
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 60.0);
+        $expected = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'baz' => 'bat',
+        ];
+        $test     = [];
+        foreach ($this->container as $key => $value) {
+            $test[$key] = $value;
+        }
+        self::assertSame($expected, $test);
+
+        // Second hop
+        $storage->setMetadata('_REQUEST_ACCESS_TIME', $ts + 120.0);
+        $expected = ['bar' => 'baz'];
+        $test     = [];
+        foreach ($this->container as $key => $value) {
+            $test[$key] = $value;
+        }
+        self::assertSame($expected, $test);
+    }
+
+    public function testIterationHonorsExpirationTimestamps(): void
+    {
+        self::assertIsInt($_SERVER['REQUEST_TIME']);
+        $this->container->foo = 'bar';
+        $this->container->bar = 'baz';
+        $storage              = $this->manager->getStorage();
+        $storage->setMetadata('Default', ['EXPIRE_KEYS' => ['foo' => $_SERVER['REQUEST_TIME'] - 18600]]);
+        $expected = ['bar' => 'baz'];
+        $test     = [];
+        foreach ($this->container as $key => $value) {
+            $test[$key] = $value;
+        }
+        self::assertSame($expected, $test);
+    }
+
+    public function testValidationShouldNotRaiseErrorForMissingResponseObject(): void
+    {
+        $session       = new LazyContainer('test');
+        $session->test = 42;
+        self::assertEquals(42, $session->test);
+    }
+
+    public function testExchangeArray(): void
+    {
+        $this->container->offsetSet('old', 'old');
+        self::assertTrue($this->container->offsetExists('old'));
+
+        $old = $this->container->exchangeArray(['new' => 'new']);
+        self::assertArrayHasKey('old', $old, "'exchangeArray' doesn't return an array of old items");
+        self::assertFalse($this->container->offsetExists('old'), "'exchangeArray' doesn't remove old items");
+        self::assertTrue($this->container->offsetExists('new'), "'exchangeArray' doesn't add the new array items");
+    }
+
+    public function testExchangeArrayObject(): void
+    {
+        $this->container->offsetSet('old', 'old');
+        self::assertTrue($this->container->offsetExists('old'));
+
+        $old = $this->container->exchangeArray(new ArrayStorage(['new' => 'new']));
+        self::assertArrayHasKey('old', $old, "'exchangeArray' doesn't return an array of old items");
+        self::assertFalse($this->container->offsetExists('old'), "'exchangeArray' doesn't remove old items");
+        self::assertTrue($this->container->offsetExists('new'), "'exchangeArray' doesn't add the new array items");
+    }
+
+    public function testMultiDimensionalUnset(): void
+    {
+        $this->container->foo = ['bar' => 'baz'];
+        unset($this->container['foo']['bar']);
+        self::assertSame([], $this->container->foo);
+    }
+
+    public function testUpgradeBehaviors(): void
+    {
+        $storage        = $this->manager->getStorage();
+        $storage['foo'] = new ArrayObject(['bar' => 'baz']);
+
+        $container = new LazyContainer('foo', $this->manager);
+        self::assertEquals('baz', $container->bar);
+        $container->baz = 'boo';
+        self::assertEquals('boo', $storage['foo']['baz']);
+    }
+
+    public function testGetArrayCopyAfterExchangeArray(): void
+    {
+        $this->container->exchangeArray(['foo' => 'bar']);
+
+        $contents = $this->container->getArrayCopy();
+
+        self::assertIsArray($contents);
+        self::assertArrayHasKey('foo', $contents, "'getArrayCopy' doesn't return exchanged array");
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testWriteStartsSession(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        // A read with no cookie should leave things unstarted first.
+        self::assertNull($container['foo']);
+        self::assertFalse($this->manager->sessionExists());
+
+        // A write must still start the session correctly.
+        $container['foo'] = 'bar';
+
+        self::assertTrue($this->manager->sessionExists());
+        self::assertSame('bar', $container['foo']);
+
+        $storage = $this->manager->getStorage();
+        self::assertSame('bar', $storage['Default']['foo']);
+    }
+
+    #[RunInSeparateProcess]
+    public function testSetExpirationSecondsStartsSession(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertFalse($this->manager->sessionExists());
+
+        $container->setExpirationSeconds(3600);
+
+        self::assertTrue($this->manager->sessionExists());
+    }
+
+    #[RunInSeparateProcess]
+    public function testSetExpirationHopsStartsSession(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertFalse($this->manager->sessionExists());
+
+        $container->setExpirationHops(2);
+
+        self::assertTrue($this->manager->sessionExists());
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testExchangeArrayStartsSession(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertFalse($this->manager->sessionExists());
+
+        $old = $container->exchangeArray(['foo' => 'bar']);
+
+        self::assertTrue($this->manager->sessionExists());
+        self::assertSame([], $old);
+        self::assertSame('bar', $container['foo']);
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testReadingWhenCookieIsPresentStartsSession(): void
+    {
+        $_COOKIE[$this->manager->getName()] = 'fakeexistingsessionid1234567890';
+
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertNull($container['foo']);
+        self::assertTrue($this->manager->sessionExists());
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testOffsetGetReturnsNullWhenNoSessionAndNoCookiePresent(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertNull($container['foo']);
+        self::assertFalse($this->manager->sessionExists());
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testOffsetGetReturnsProvidedDefault(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertSame('fallback', $container->offsetGet('foo', 'fallback'));
+        self::assertFalse($this->manager->sessionExists());
+    }
+
+    #[RunInSeparateProcess]
+    #[IgnoreDeprecations]
+    public function testOffsetExistsReturnsFalseWithNoSession(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertFalse(isset($container['foo']));
+        self::assertFalse($this->manager->sessionExists());
+    }
+
+    #[RunInSeparateProcess]
+    public function testGetIteratorReturnsEmptyWithNoSession(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        $test = [];
+        foreach ($container->getIterator() as $key => $value) {
+            $test[$key] = $value;
+        }
+
+        self::assertSame([], $test);
+        self::assertFalse($this->manager->sessionExists());
+    }
+
+    #[RunInSeparateProcess]
+    public function testGetArrayCopyReturnsEmptyWithNoSession(): void
+    {
+        $container = new LazyContainer('Default', $this->manager);
+
+        self::assertSame([], $container->getArrayCopy());
+        self::assertFalse($this->manager->sessionExists());
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| RFC           | yes
| New Feature   | yes
| Documentation | yes


### Description

RFC for "lazy session container" feature mentioned in issue #21 .

To be honest i am not entirely sure what the requirements for this feature are - should it simply provide a way to not start the session when using `AbstractContainer` implementations? Or it the goal to implement a similar feature to `mezzio-session's LazySession`? 

The `mezzio-session` example provides a way to persist data in memory before starting the session, something that is not available in this package. This would require adding this mechanism from scratch (or bring in ` mezzio-session-ext` to this repo as well), and to be honest i'm not sure what the use case here would be when `mezzio-session` already covers the "Middleware-first approach".

For the purposes of discussing this, i went with the first option, with adding a new `LazyContainer` instead of changing the original `Container`. This new container simply defers starting the session when reading, as opposed to the `Container` calling `AbstractContainer::__construct` which automatically starts the session. Writing will always start the session, as per the issue's first point. 
Also adapted `ContainerAbstractServiceFactory` to allow instantiating`LazyContainer` instances, like the original `Container` ones (which are kept as the default `AbstractContainer` implementation used).


I could use more feedback about what exactly a "lazy container" should do in this project.

Since this is mostly a "proof of concept" implementation, the tests suite is a bit basic (duplicated `Container's` tests and added specific read/write session starting checks only). I'm also aware of the Psalm issues, which i'll of course resolve once a way forward is agreed upon, as well as expanding the test suite.


<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->
